### PR TITLE
[#20] 결제 시스템 - PG 요청/승인 절차 구현

### DIFF
--- a/src/main/java/com/projectboard/payment/checkout/CheckoutController.java
+++ b/src/main/java/com/projectboard/payment/checkout/CheckoutController.java
@@ -1,21 +1,28 @@
 package com.projectboard.payment.checkout;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.projectboard.payment.order.Order;
+import com.projectboard.payment.order.OrderRepository;
+import com.projectboard.payment.processing.PaymentProcessingService;
+import com.projectboard.payment.order.OrderStatus;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.client.RestClient;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
+/**
+ * 체크아웃 컨트롤러
+ * - 주문 생성, 결제 페이지 진입, 결제 승인 처리 등을 담당.
+ * - 결제 성공 및 실패 페이지 렌더링.
+ */
 @Slf4j
 @Controller
+@AllArgsConstructor
 public class CheckoutController {
     /*
     TODO:
@@ -43,7 +50,7 @@ public class CheckoutController {
         - 환불 상태를 사용자에게 알림.
 
     6. UI/UX 개선 (선택 사항)
-        - 결제 페이지의 사용자 경험 개선.
+        - 후원 페이지 및 결제 페이지 디자인 개선.
         - 마이페이지에서 후원 및 결제 내역 확인 기능 추가.
         - 관리자 페이지에서 결제 및 환불 내역 관리 기능 추가.
 
@@ -60,6 +67,51 @@ public class CheckoutController {
         - 결제 관련 API 호출 시, 인증 및 권한 부여 구현.
         - 민감한 정보(예: 시크릿 키) 보호.
     */
+
+    private final OrderRepository orderRepository;
+    private final PaymentProcessingService paymentProcessingService;
+
+    /**
+     * 주문 생성 페이지
+     * - 사용자가 결제할 금액과 주문 ID를 확인하는 화면.
+     * - templates/payment/order.html 뷰를 렌더링.
+     */
+    @GetMapping("/order")
+    public String order(
+            @RequestParam("userId") Long userId,
+            @RequestParam("amount") String amount,
+            @RequestParam("donationId") Long donationId,
+            @RequestParam("donationName") String donationName,
+            Model model
+    ) {
+        Order order = new Order();
+        order.setAmount(new BigDecimal(amount));
+        order.setDonationId(donationId);
+        order.setDonationName(donationName);
+        order.setUserId(userId);
+        order.setRequestId(UUID.randomUUID().toString());
+        order.setStatus(OrderStatus.WAIT);
+        order.setCreatedAt(LocalDateTime.now());
+        order.setUpdatedAt(LocalDateTime.now());
+        orderRepository.save(order);
+
+        model.addAttribute("donationName", donationName);
+        model.addAttribute("requestId", order.getRequestId());
+        model.addAttribute("amount", amount);
+        model.addAttribute("customerKey", "customerKey-" + userId);
+
+        return "payment/order";
+    }
+
+    /**
+     * 주문 요청 페이지
+     * - 사용자가 결제할 금액과 주문 ID를 확인하는 화면.
+     * - templates/payment/order-requested.html 뷰를 렌더링.
+     */
+    @GetMapping("/order-requested")
+    public String orderRequested() {
+        return "payment/order-requested";
+    }
 
     /**
      * 결제 페이지 진입
@@ -82,9 +134,9 @@ public class CheckoutController {
     }
 
     /**
-     * 결제 성공 페이지
-     * - Toss 결제 성공 후 redirect 될 URL
-     * - templates/payment/success.html 렌더링
+     * 결제 실패 페이지
+     * - Toss 결제 실패 후 redirect 될 URL
+     * - templates/payment/fail.html 렌더링
      */
     @GetMapping("/fail")
     public String fail() {
@@ -97,51 +149,31 @@ public class CheckoutController {
      * - 서버는 이 데이터를 Toss Payments API로 전달하여 결제를 "승인(confirm)"함.
      * - 이 과정을 통해 결제가 최종적으로 확정되고, DB에 내역을 저장할 수 있음.
      */
-    @RequestMapping(value = "/confirm")
-    public ResponseEntity<Object> confirmPayment(@RequestBody String jsonBody) throws Exception {
-        // 1. 프론트엔드에서 전달받은 JSON(body)을 파싱
-        final JsonNode jsonNode = new ObjectMapper().readTree(jsonBody);
+    @RequestMapping(method = RequestMethod.POST, value = "/confirm")
+    public ResponseEntity<Object> confirmPayment(@RequestBody ConfirmRequest confirmRequest) throws Exception {
+       /*
+       1. 주문 서비스 - 주문 상태가 변경됨 -> REQUESTED
+       2. 주문 서비스 - 결제 서비스 승인 요청 (POST API /confirm)
+       3. 결제 서비스 - PG 승인 요청
+       4. 결제 서비스 - 결제 기록 저장
+          - 결제 수단으로 바로 결제하는 메서드 구현
+       ...
+       6. 주문 서비스에 응답
+       7. 주문 서비스에서 주문 상태가 변경됨 -> APPROVED
+       8. 주문 서비스 - 후원 내역 저장
+        */
 
-        // 2. ConfirmRequest DTO로 변환 (결제승인 API에 필요한 필드만 추출)
-        final ConfirmRequest request = new ConfirmRequest(
-                jsonNode.get("paymentKey").asText(), // 결제 고유키
-                jsonNode.get("orderId").asText(),    // 주문 ID
-                jsonNode.get("amount").asText()      // 결제 금액
-        );
+        // 1. 주문 상태 변경 (WAIT -> REQUESTED)
+        Order order = orderRepository.findByRequestId(confirmRequest.orderId());
+        order.setUpdatedAt(LocalDateTime.now());
+        order.setStatus(OrderStatus.REQUESTED);
+        orderRepository.save(order);
 
-        // 3. Toss Payments 인증 헤더 생성
-        // - Toss API는 Basic Auth 방식 사용
-        // - 사용자명: 시크릿 키, 비밀번호: 없음
-        // - "시크릿키:" 문자열을 Base64 인코딩하여 Authorization 헤더에 포함
-        String widgetSecretKey = "test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6";     // 테스트용 시크릿 키
-        Base64.Encoder encoder = Base64.getEncoder();                          // Base64 인코더
-        byte[] encodedBytes = encoder.encode((widgetSecretKey + ":").getBytes(StandardCharsets.UTF_8)); // "시크릿키:" 문자열을 UTF-8 바이트로 변환 후 Base64 인코딩
-        String authorizations = "Basic " + new String(encodedBytes);           // "Basic " 접두어를 붙여 최종 인증 문자열 생성
+        // 2. 결제 승인 요청
+        paymentProcessingService.createPayment(confirmRequest);
 
-        // 4. RestClient로 Toss Payments API 호출
-        RestClient defaultClient = RestClient.create();
-
-        // 5. POST 요청을 보내고, 응답을 Object 타입으로 매핑
-        final Object object = defaultClient.post()                             // HTTP POST 요청
-                .uri("https://api.tosspayments.com/v1/payments/confirm")   // 결제 승인 API URL
-                .headers(httpHeaders -> {                           // 요청 헤더 설정
-                    httpHeaders.set("Authorization", authorizations);          // 인증 헤더
-                    httpHeaders.set("Content-Type", "application/json");       // 요청 바디 JSON 형식
-                })
-                .contentType(MediaType.APPLICATION_JSON)                       // 요청 Content-Type
-                .body(request)                                                 // 요청 본문 (ConfirmRequest 직렬화됨)
-                .retrieve()                                                    // 요청 전송
-                .toEntity(Object.class);                                       // 응답을 Object 타입으로 매핑
-
-        // 6. Toss에서 받은 응답을 클라이언트로 그대로 반환
-        return ResponseEntity.ok(object);
+        // 3. 주문 서비스에 응답
+        return ResponseEntity.ok(null);
     }
-
-    /**
-     * Confirm API 요청에 필요한 DTO
-     * - paymentKey/orderId/amount 필드만 포함
-     */
-    public record ConfirmRequest(String paymentKey, String orderId, String amount
-    ) {}
 
 }

--- a/src/main/java/com/projectboard/payment/checkout/ConfirmRequest.java
+++ b/src/main/java/com/projectboard/payment/checkout/ConfirmRequest.java
@@ -1,0 +1,9 @@
+package com.projectboard.payment.checkout;
+
+/**
+ * Confirm API 요청에 필요한 DTO
+ * - paymentKey/orderId/amount 필드만 포함
+ */
+public record ConfirmRequest(String paymentKey, String orderId, String amount
+) {
+}

--- a/src/main/java/com/projectboard/payment/external/PaymentGatewayService.java
+++ b/src/main/java/com/projectboard/payment/external/PaymentGatewayService.java
@@ -1,0 +1,63 @@
+package com.projectboard.payment.external;
+
+import com.projectboard.payment.checkout.ConfirmRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * 결제 게이트웨이 서비스
+ * - 외부 결제 게이트웨이(Toss Payments)와의 통신을 담당하는 서비스 클래스.
+ * - 결제 승인 요청을 보내고, 응답을 처리.
+ */
+@Service
+@AllArgsConstructor
+public class PaymentGatewayService {
+
+    private static final Base64.Encoder encoder = Base64.getEncoder();                    // Base64 인코더
+    private static final String SECRET = "test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6";        // 테스트용 시크릿 키
+    private static final String URL = "https://api.tosspayments.com/v1/payments/confirm"; // 결제 승인 API URL
+
+    // 결제 승인 요청
+    // - ConfirmRequest 객체를 받아 Toss Payments API에 승인 요청을 보냄
+    public void confirm(ConfirmRequest confirmRequest) {
+
+        // ===== Toss Payments API 호출 =====
+        // 1. Toss Payments 인증 헤더 생성
+        // - Toss API는 Basic Auth 방식 사용
+        // - 사용자명: 시크릿 키, 비밀번호: 없음
+        // - "시크릿키:" 문자열을 Base64 인코딩하여 Authorization 헤더에 포함
+        byte[] encodedBytes = encoder.encode((SECRET + ":").getBytes(StandardCharsets.UTF_8)); // "시크릿키:" 문자열을 UTF-8 바이트로 변환 후 Base64 인코딩
+        String authorizations = "Basic " + new String(encodedBytes);           // "Basic " 접두어를 붙여 최종 인증 문자열 생성
+
+        // 2. RestClient로 Toss Payments API 호출
+        RestClient defaultClient = RestClient.create();
+
+        // 3. POST 요청을 보내고, 응답을 Object 타입으로 매핑
+        final ResponseEntity<Object> object = defaultClient.post()             // HTTP POST 요청
+                .uri(URL)                                                      // 결제 승인 API URL
+                .headers(httpHeaders -> {                           // 요청 헤더 설정
+                    httpHeaders.set("Authorization", authorizations);          // 인증 헤더
+                    httpHeaders.set("Content-Type", "application/json");       // 요청 바디 JSON 형식
+                })
+                .contentType(MediaType.APPLICATION_JSON)                       // 요청 Content-Type
+                .body(confirmRequest)                                          // 요청 본문 (ConfirmRequest 직렬화됨)
+                .retrieve()                                                    // 요청 전송
+                .toEntity(Object.class);                                       // 응답을 Object 타입으로 매핑
+
+        // 4. 응답 상태 코드가 4xx/5xx인 경우 예외 처리
+        if (object.getStatusCode().isError()) {
+            throw new IllegalArgumentException("결제 요청이 실패했습니다.");
+        }
+    }
+
+    // Toss Payments API 응답 매핑용 record 클래스
+    public record Response(String paymentKey, String orderId, String orderName, String status, String amount) {
+    }
+
+}

--- a/src/main/java/com/projectboard/payment/order/Order.java
+++ b/src/main/java/com/projectboard/payment/order/Order.java
@@ -1,0 +1,50 @@
+package com.projectboard.payment.order;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Entity
+@Table(name = "temp_order")
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본 키, 자동 생성
+    private Long id;
+
+    @Column(name = "user_id", nullable = false) // null 금지, 고유 제약 조건은 @Table에서 설정
+    private Long userId;
+
+    private BigDecimal amount;
+
+    private String requestId;
+    private Long donationId;
+    private String donationName;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+    // createdAt, updatedAt 자동 설정
+    @PrePersist
+    void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    // updatedAt 자동 갱신
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/projectboard/payment/order/OrderRepository.java
+++ b/src/main/java/com/projectboard/payment/order/OrderRepository.java
@@ -1,0 +1,22 @@
+package com.projectboard.payment.order;
+
+import com.projectboard.payment.wallet.Wallet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * OrderRepository
+ * - 주문 관련 데이터베이스 작업을 처리하는 리포지토리 인터페이스.
+ * - JpaRepository를 상속하여 기본 CRUD 기능 제공.
+ */
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    // 특정 사용자의 주문 조회
+    Order findByUserId(Long userId);
+
+    // 특정 요청 ID로 주문 조회
+    Order findByRequestId(String requestId);
+}

--- a/src/main/java/com/projectboard/payment/order/OrderStatus.java
+++ b/src/main/java/com/projectboard/payment/order/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.projectboard.payment.order;
+
+public enum OrderStatus {
+    WAIT, REQUESTED, APPROVED, FAIL, CANCEL
+}

--- a/src/main/java/com/projectboard/payment/processing/PaymentProcessingService.java
+++ b/src/main/java/com/projectboard/payment/processing/PaymentProcessingService.java
@@ -1,0 +1,54 @@
+package com.projectboard.payment.processing;
+
+import com.projectboard.payment.checkout.ConfirmRequest;
+import com.projectboard.payment.external.PaymentGatewayService;
+import com.projectboard.payment.order.Order;
+import com.projectboard.payment.order.OrderRepository;
+import com.projectboard.payment.order.OrderStatus;
+import com.projectboard.payment.transaction.TransactionService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+/**
+ * 결제 처리 서비스
+ * - 결제 승인 요청 및 결제 기록 저장을 담당.
+ * - 주문 상태 업데이트 및 후원 내역 저장.
+ */
+@Service
+@AllArgsConstructor
+public class PaymentProcessingService {
+    private final PaymentGatewayService paymentGatewayService;
+    private final TransactionService transactionService;
+
+    private final OrderRepository orderRepository;
+
+    // ===== 결제 처리 =====
+    // - 결제 승인 요청 및 결제 기록 저장
+    // - 주문 상태 업데이트 및 후원 내역 저장
+    public void createPayment(ConfirmRequest confirmRequest) {
+       /*
+       3. 결제 서비스 - PG 승인 요청
+       4. 결제 서비스 - 결제 기록 저장
+          - 결제 수단으로 바로 결제하는 메서드 구현
+       ...
+       6. 주문 서비스에 응답
+       7. 주문 서비스 - 주문 상태가 변경됨 -> APPROVED
+       8. 주문 서비스 - 후원 내역 저장
+        */
+
+        // PG 승인 요청
+        paymentGatewayService.confirm(confirmRequest);
+
+        // FIXME: pgPayment() 메서드 내에서 결제 기록 저장 로직 구현 필요
+        // 결제 기록 저장
+        transactionService.pgPayment();
+
+        // 주문 상태 변경
+        final Order order = orderRepository.findByRequestId(confirmRequest.orderId());
+        order.setStatus(OrderStatus.APPROVED);
+        order.setUpdatedAt(LocalDateTime.now());
+        orderRepository.save(order);
+    }
+}

--- a/src/main/java/com/projectboard/payment/transaction/TransactionService.java
+++ b/src/main/java/com/projectboard/payment/transaction/TransactionService.java
@@ -8,6 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+
+/**
+ * 트랜잭션 서비스
+ * - 충전 및 결제 트랜잭션 처리를 담당.
+ * - 멱등성 보장 및 잔액 업데이트 로직 포함.
+ */
 @Service
 @RequiredArgsConstructor
 public class TransactionService {
@@ -101,4 +108,20 @@ public class TransactionService {
             return new PaymentTransactionResponse(existing.getWalletId(), existing.getAmount());
         }
     }
+
+    // TODO: PG 결제 기록 저장 로직 구현 필요
+    // - 실제 PG 연동 후 구현
+    // - 임시 더미 메서드
+    public void pgPayment() {
+
+        // 임시: 더미 결제 기록 저장
+        final Transaction transaction = Transaction.createPaymentTransaction(
+                1L, 20L,
+                "30", new BigDecimal(1000)
+        );
+        transactionRepository.save(
+                transaction
+        );
+    }
+
 }

--- a/src/main/resources/application-payment.yaml
+++ b/src/main/resources/application-payment.yaml
@@ -32,7 +32,7 @@ spring:
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
-    hibernate.ddl-auto: create
+    hibernate.ddl-auto: update
     show-sql: true
     properties:
       hibernate.format_sql: true

--- a/src/main/resources/templates/payment/order-requested.html
+++ b/src/main/resources/templates/payment/order-requested.html
@@ -1,0 +1,66 @@
+<!-- 결제 성공 후 호출되는 페이지.
+    - URL 파라미터에서 결제 정보를 추출하고, 서버에 결제 승인 요청을 보냄
+    - 결제 승인에 실패하면 실패 페이지로 리디렉션 -->
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="utf-8" />
+</head>
+<body>
+<h2>결제 성공</h2>
+<p id="paymentKey"></p>
+<p id="orderId"></p>
+<p id="amount"></p>
+
+<script>
+    // URLSearchParams 객체를 사용하여 쿼리 파라미터 추출
+    const urlParams = new URLSearchParams(window.location.search);  // URL의 쿼리 파라미터를 가져옴
+    const paymentKey = urlParams.get("paymentKey");                 // paymentKey 값 추출
+    const orderId = urlParams.get("orderId");                       // orderId 값 추출
+    const amount = urlParams.get("amount");                         // amount 값 추출
+
+    // 결제 승인 API 요청
+    async function confirm() {
+        const requestData = {
+            paymentKey: paymentKey,
+            orderId: orderId,
+            amount: amount,
+        };
+
+        // 서버의 /confirm 엔드포인트로 결제 승인 요청
+        const response = await fetch("/confirm", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(requestData),
+        });
+
+        // 응답 데이터를 JSON으로 파싱
+        const json = await response.json();
+
+        // 결제 실패 시 처리
+        if (!response.ok) {
+            // 결제 실패 비즈니스 로직을 구현하세요.
+            console.log(json);
+            window.location.href = `/fail?message=${json.message}&code=${json.code}`;
+        }
+
+        // 결제 성공 비즈니스 로직을 구현하세요.
+        console.log(json);
+    }
+
+    // 페이지 로드 시 결제 승인 요청
+    confirm();
+
+    // 결제 정보를 화면에 표시
+    const paymentKeyElement = document.getElementById("paymentKey");
+    const orderIdElement = document.getElementById("orderId");
+    const amountElement = document.getElementById("amount");
+
+    orderIdElement.textContent = "주문번호: " + orderId;
+    amountElement.textContent = "결제 금액: " + amount;
+    paymentKeyElement.textContent = "paymentKey: " + paymentKey;
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/payment/order.html
+++ b/src/main/resources/templates/payment/order.html
@@ -1,0 +1,65 @@
+<!-- 설명: 결제 페이지
+    - 결제 위젯을 렌더링하고, 결제 요청을 처리하는 페이지 -->
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="utf-8" />
+    <script src="https://js.tosspayments.com/v1/payment-widget"></script>
+</head>
+<body>
+<!-- 결제 UI, 이용약관 UI 영역 -->
+<div id="payment-method"></div>
+<div id="agreement"></div>
+<!-- 후원명, 가격, requestId, customerKey -->
+<p th:text="${donationName}"></p>
+<p th:text="${amount}"></p>
+<p th:text="${requestId}"></p>
+<p th:text="${customerKey}"></p>
+
+<!-- 결제하기 버튼 -->
+<button id="payment-button">결제하기</button>
+
+<script>
+    // 결제에 필요한 정보 설정
+    const coupon = document.getElementById("coupon-box");
+    const button = document.getElementById("payment-button");
+    const amount = `[[${amount}]]`
+    const orderName = `[[${donationName}]]`
+    const orderId = `[[${requestId}]]`
+    // 구매자의 고유 아이디를 불러와서 customerKey로 설정하세요.
+    const customerKey = `[[${customerKey}]]`
+
+    // 테스트용 고객 키입니다. 실제 서비스에서는 회원의 고유값으로 설정하세요.
+    const widgetClientKey = "test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm";
+    // PaymentWidget 객체 생성
+    // customerKey는 회원의 고유값으로 설정해야 합니다.
+    const paymentWidget = PaymentWidget(widgetClientKey, customerKey); // 고객 고유값 설정
+
+    // 결제 수단, 이용약관 UI 렌더링
+    const paymentMethodWidget = paymentWidget.renderPaymentMethods(
+        "#payment-method",
+        { value: amount },
+        { variantKey: "DEFAULT" }
+    );
+
+    // 이용약관 UI 렌더링
+    paymentWidget.renderAgreement(
+        "#agreement",
+        { variantKey: "AGREEMENT" }
+    );
+
+    // 결제하기 버튼에 클릭 이벤트 설정
+    button.addEventListener("click", function () {
+        paymentWidget.requestPayment({      // 결제 요청
+            orderId: orderId,
+            orderName: orderName,
+            successUrl: window.location.origin + "/order-requested",
+            failUrl: window.location.origin + "/fail",
+            customerEmail: "customer123@gmail.com",
+            customerName: "김토스",
+            customerMobilePhone: "01012341234",
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/test/java/com/projectboard/payment/PaymentGatewayServiceIntgTest.java
+++ b/src/test/java/com/projectboard/payment/PaymentGatewayServiceIntgTest.java
@@ -1,0 +1,67 @@
+package com.projectboard.payment;
+
+import com.projectboard.payment.checkout.ConfirmRequest;
+import com.projectboard.payment.external.PaymentGatewayService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+public class PaymentGatewayServiceIntgTest {
+
+    // 테스트 결과 로거: 성공/실패/중단/비활성 상태 콘솔 출력
+    @RegisterExtension
+    static TestWatcher logWatcher = new TestWatcher() {
+        @Override
+        public void testSuccessful(ExtensionContext context) {
+            System.out.println("✅ PASSED: " + context.getDisplayName());
+        }
+
+        @Override
+        public void testFailed(ExtensionContext context, Throwable cause) {
+            System.err.println("❌ FAILED: " + context.getDisplayName());
+            cause.printStackTrace(); // 빨간 스택트레이스 출력
+        }
+
+        @Override
+        public void testAborted(ExtensionContext context, Throwable cause) {
+            System.err.println("⚠️ ABORTED: " + context.getDisplayName());
+        }
+
+        @Override
+        public void testDisabled(ExtensionContext context, Optional<String> reason) {
+            System.out.println("⏸ DISABLED: " + context.getDisplayName() +
+                    reason.map(r -> " — " + r).orElse(""));
+        }
+    };
+
+    @Autowired
+    PaymentGatewayService paymentGatewayService;
+
+    // 연결 테스트용
+    @Test
+    public void test() {
+        // given - when - then 패턴 없이 실제 API 호출 테스트
+        // 실제 결제 승인 API 호출
+        paymentGatewayService.confirm(
+                new ConfirmRequest(
+                        "tgen_20250909194737fMDG2",
+                        "9d4e4aae-1e1c-47a0-a4ba-9e6ba07b4653",
+                        "1000"
+                )
+        );
+
+        // 성공 시 예외 없음, 실패 시 예외 발생
+
+        // 디버깅 출력
+        System.out.println("✅ PaymentGatewayServiceIntgTest completed successfully.");
+    }
+}

--- a/src/test/java/com/projectboard/payment/PaymentProcessingServiceTest.java
+++ b/src/test/java/com/projectboard/payment/PaymentProcessingServiceTest.java
@@ -1,0 +1,120 @@
+package com.projectboard.payment;
+
+import com.projectboard.payment.checkout.ConfirmRequest;
+import com.projectboard.payment.external.PaymentGatewayService;
+import com.projectboard.payment.order.Order;
+import com.projectboard.payment.order.OrderRepository;
+import com.projectboard.payment.order.OrderStatus;
+import com.projectboard.payment.processing.PaymentProcessingService;
+import com.projectboard.payment.transaction.TransactionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+public class PaymentProcessingServiceTest {
+
+    // 테스트 결과 로거: 성공/실패/중단/비활성 상태 콘솔 출력
+    @RegisterExtension
+    static TestWatcher logWatcher = new TestWatcher() {
+        @Override
+        public void testSuccessful(ExtensionContext context) {
+            System.out.println("✅ PASSED: " + context.getDisplayName());
+        }
+
+        @Override
+        public void testFailed(ExtensionContext context, Throwable cause) {
+            System.err.println("❌ FAILED: " + context.getDisplayName());
+            cause.printStackTrace(); // 빨간 스택트레이스 출력
+        }
+
+        @Override
+        public void testAborted(ExtensionContext context, Throwable cause) {
+            System.err.println("⚠️ ABORTED: " + context.getDisplayName());
+        }
+
+        @Override
+        public void testDisabled(ExtensionContext context, Optional<String> reason) {
+            System.out.println("⏸ DISABLED: " + context.getDisplayName() +
+                    reason.map(r -> " — " + r).orElse(""));
+        }
+    };
+
+    // System under test
+    private PaymentProcessingService paymentProcessingService; // 테스트 대상 서비스
+
+    // Mocked dependencies
+    private PaymentGatewayService paymentGatewayService;       // PG 서비스 (모킹)
+    private TransactionService transactionService;             // 거래 서비스 (모킹)
+    private OrderRepository orderRepository;                   // 주문 리포지토리 (모킹)
+
+    @BeforeEach
+    // 각 테스트 전에 실행되어 모킹된 의존성을 초기화하고 서비스 인스턴스를 생성
+    void setUp() {
+        paymentGatewayService = mock(PaymentGatewayService.class); // PG 서비스 모킹
+        transactionService = mock(TransactionService.class);       // 거래 서비스 모킹
+        orderRepository = mock(OrderRepository.class);             // 주문 리포지토리 모킹
+
+        // PaymentProcessingService 인스턴스 생성
+        paymentProcessingService = new PaymentProcessingService(
+                paymentGatewayService, transactionService, orderRepository // 모킹된 의존성 주입
+        );
+    }
+
+    @Test
+    @DisplayName("PG 결제 성공 시 결제 기록이 생성되고 주문이 APPROVED 된다")
+    void createPayment_success() {
+        // given
+        // ConfirmRequest 생성
+        ConfirmRequest confirmRequest = new ConfirmRequest(
+                "paymentKey",
+                "orderId",
+                "1000"
+        );
+
+        // OrderRepository가 특정 주문을 반환하도록 설정
+        Order order = new Order();               // 새로운 주문 객체 생성
+        order.setStatus(OrderStatus.REQUESTED);  // 초기 상태 설정
+        order.setUpdatedAt(LocalDateTime.now()); // 초기 업데이트 시간 설정
+
+        // orderRepository가 confirmRequest.orderId()로 호출될 때 order 객체를 반환하도록 스텁 설정
+        given(orderRepository.findByRequestId(confirmRequest.orderId()))
+                .willReturn(order);
+
+        // when
+        // 결제 처리 서비스의 createPayment 메서드 호출
+        paymentProcessingService.createPayment(confirmRequest);
+
+        // then
+        // PG 승인 요청 확인
+        then(paymentGatewayService).should(times(1)).confirm(confirmRequest);
+
+        // 결제 기록 저장 확인
+        then(transactionService).should(times(1)).pgPayment();
+
+        // 주문 상태가 APPROVED 로 변경되었는지 확인
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.APPROVED);
+
+        // 주문 저장이 호출되었는지 확인
+        then(orderRepository).should(times(1)).save(order);
+
+        // 그 외 불필요한 호출 없음
+        // then(paymentGatewayService).shouldHaveNoMoreInteractions();
+        // then(transactionService).shouldHaveNoMoreInteractions();
+        // then(orderRepository).shouldHaveNoMoreInteractions();
+
+        // 디버깅 출력
+        System.out.println("Updated Order Status: " + order.getStatus());
+    }
+}


### PR DESCRIPTION
## 📌 개요
Toss Payments PG 연동을 통해 **결제 요청 → 승인 절차**를 구현.  
주문 생성, 결제 요청, PG 승인, 결제 기록 저장, 주문 상태 업데이트까지의 플로우를 구축.

---

## 🔑 주요 변경사항

### 1. **Order 도메인**
- `Order` 엔티티 추가 (`temp_order` 테이블 매핑)
  - 주문 ID, 사용자 ID, 후원 ID/이름, 금액, 상태, 생성/수정일시 관리
- `OrderStatus` enum 추가
  - WAIT, REQUESTED, APPROVED, FAIL, CANCEL
- `OrderRepository` 추가
  - `findByUserId(Long userId)`
  - `findByRequestId(String requestId)`

### 2. **CheckoutController**
- 주문 생성 `/order` → DB 저장 및 결제 페이지 진입
- 결제 요청 `/checkout` → Toss 위젯 호출
- 결제 성공 `/success`, 결제 실패 `/fail` → 뷰 렌더링
- 결제 승인 `/confirm`
  - PG 승인 요청 → 결제 처리 서비스 위임
  - 주문 상태 변경 (WAIT → REQUESTED → APPROVED)

### 3. **뷰 (Thymeleaf)**
- `order.html`
  - 결제 위젯 초기화 및 결제 요청 처리
- `order-requested.html`
  - 결제 성공 후 승인 API 호출 및 결과 출력
- `checkout.html`, `success.html`, `fail.html` 추가 및 결제 플로우 구성

### 4. **결제 처리 서비스**
- `PaymentProcessingService`
  - PG 승인 요청 및 결제 기록 저장
  - 주문 상태 APPROVED 로 업데이트
- `PaymentGatewayService`
  - Toss Payments API 호출 (`/v1/payments/confirm`)
  - Basic Auth 헤더 설정 및 결제 승인 처리
- `TransactionService`
  - `pgPayment()` 더미 메서드 추가 (향후 PG 결제 기록 저장 구현 예정)

### 5. **테스트 코드**
- `PaymentProcessingServiceTest`
  - PG 승인 성공 시 결제 기록 생성 및 주문 상태 APPROVED 검증
- `PaymentGatewayServiceIntgTest`
  - 실제 Toss API 연동 테스트 (성공 시 예외 없음)

### 6. **환경 설정**
- `application-payment.yaml`
  - Hibernate `ddl-auto: update`로 변경
  - MySQL 저장 데이터 유지 및 이어쓰기 가능하도록 설정

---

## ✅ 완료 조건
- 주문 생성 시 DB에 Order 저장
- Toss PG 위젯 연동 및 결제 요청
- 결제 성공 시 PG 승인 API 호출
- 승인 성공 시 결제 기록 저장 및 주문 상태 APPROVED
- 결제 실패 시 FAIL 페이지 이동 및 에러 메시지 표시
- 통합/단위 테스트로 기본 동작 검증 완료

---

## 🚀 향후 과제
- `TransactionService.pgPayment()`에 실제 결제 기록 저장 로직 구현
- 후원 내역 저장 및 마이페이지/관리자 페이지 결제 내역 조회 기능 추가
- 환불 처리 및 관련 API 연동
- 보안 강화 (시크릿 키 외부화, 프로필별 환경 분리)