### PR TITLE
[#29] 결제 시스템 - Wallet 모델 리팩터링: AddBalanceWalletResponse DTO 필드 네이밍 통일 (id → walletId)

### DIFF
--- a/src/main/java/com/projectboard/payment/wallet/AddBalanceWalletResponse.java
+++ b/src/main/java/com/projectboard/payment/wallet/AddBalanceWalletResponse.java
@@ -4,14 +4,15 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
- * 지갑 잔액 추가 응답 DTO
- * - id: 지갑 ID
- * - userId: 사용자 ID
- * - balance: 현재 잔액
- * - createdAt: 생성 일시
- * - updatedAt: 수정 일시
+ * AddBalanceWalletResponse
+ * - 지갑 잔액 추가 응답 DTO
+ * - 지갑 ID, 사용자 ID, 잔액, 생성 시각, 업데이트 시각 포함
  */
 public record AddBalanceWalletResponse(
-        Long id, Long userId, BigDecimal balance, LocalDateTime createdAt, LocalDateTime updatedAt
+        Long walletId,
+        Long userId,
+        BigDecimal balance,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
 ) {
 }


### PR DESCRIPTION
# PR 제목
리팩터링: AddBalanceWalletResponse DTO 필드 네이밍 통일 (id → walletId)

# PR 내용
## 개요
- 기존 `AddBalanceWalletResponse` DTO에서 지갑 식별자 필드명을 `id`로 사용하고 있었음.
- 다른 DTO/엔티티(`Wallet`, `CreateWalletResponse` 등)에서는 `walletId`라는 이름을 사용 중이었음.
- 필드 네이밍 불일치로 인해 혼동 가능성이 있었으므로, `id` → `walletId`로 통일하여 일관성을 확보함.

## 변경 사항
- `AddBalanceWalletResponse` DTO의 필드명 변경  
  - `id` → `walletId`
- 클래스 주석 및 필드 주석 수정 (지갑 ID 명시)
- 해당 DTO를 사용하는 서비스/테스트 코드에서의 필드명 참조 부분 일괄 변경

## 완료 조건
- [x] `AddBalanceWalletResponse`의 필드명을 `walletId`로 변경
- [x] 주석/문서에서 `id`를 `walletId`로 반영
- [x] 서비스 및 테스트 코드 컴파일/실행 시 정상 동작 확인
- [x] 관련 단위 테스트 통과

## 기타
- 이번 변경으로 지갑 관련 DTO/엔티티의 네이밍이 통일되어 가독성과 유지보수성이 향상됨.
