### PR TITLE
[#33] 결제 시스템 - 통합 테스트 전용 application-payment-test.yaml 설정 분리 및 적용

### DIFF
--- a/src/test/java/com/projectboard/payment/PaymentGatewayServiceIntgTest.java
+++ b/src/test/java/com/projectboard/payment/PaymentGatewayServiceIntgTest.java
@@ -2,6 +2,7 @@ package com.projectboard.payment;
 
 import com.projectboard.payment.checkout.ConfirmRequest;
 import com.projectboard.payment.external.PaymentGatewayService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -14,11 +15,16 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Optional;
 
+/**
+ * PaymentGatewayService 통합 테스트
+ * - 실제 결제 게이트웨이 API 연동 확인용 (로컬에서만 수동 실행 권장)
+ * - application-payment-test.yml 설정 사용
+ * - 테스트 결과를 콘솔에 로깅
+ */
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("payment-test") // application-payment-test.yml 설정 사용
 public class PaymentGatewayServiceIntgTest {
-
     // 테스트 결과 로거: 성공/실패/중단/비활성 상태 콘솔 출력
     @RegisterExtension
     static TestWatcher logWatcher = new TestWatcher() {
@@ -45,19 +51,24 @@ public class PaymentGatewayServiceIntgTest {
         }
     };
 
-    @Autowired
-    PaymentGatewayService paymentGatewayService;
+    // ===== 의존성 주입 =====
+    // SUT
+    @Autowired PaymentGatewayService paymentGatewayService;    // 실제 결제 게이트웨이 서비스
 
-    // 연결 테스트용
+    // ⚠️ 실제 PG 결제 승인 API 연동 확인용 테스트 (로컬에서만 수동 실행)
+    // - orderId, paymentKey는 실제 결제 건마다 달라지므로 하드코딩 불가
+    // - 따라서 CI/CD나 정기 테스트에서는 항상 실패할 수 있음
+    // - @Disabled 처리하고, 특정 상황에서만 임시 실행할 예정
     @Test
+    @Disabled("실제 PG 결제 승인 API 연동 확인용 - 로컬에서만 수동 실행")
     public void test() {
         // given - when - then 패턴 없이 실제 API 호출 테스트
         // 실제 결제 승인 API 호출
         paymentGatewayService.confirm(
                 new ConfirmRequest(
-                        "tgen_20250911175019QWb15",
-                        "1bd23f7a-9009-41f1-a1da-638a85050d0b",
-                        "1000"
+                        "tgen_20250911175019QWb15",                 // 결제 고유 ID (실제 존재하는 결제 ID로 교체 필요)
+                        "1bd23f7a-9009-41f1-a1da-638a85050d0b",               // 주문 번호 (임의 문자열)
+                        "1000"                                                // 결제 금액 (문자열)
                 )
         );
 

--- a/src/test/java/com/projectboard/payment/PaymentSystemApplicationTest.java
+++ b/src/test/java/com/projectboard/payment/PaymentSystemApplicationTest.java
@@ -4,12 +4,20 @@ import com.projectboard.payment.wallet.WalletRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+/**
+ * PaymentSystemApplicationTest
+ * - 스프링 컨텍스트 로딩 및 기본 리포지토리 동작 확인용 테스트 클래스
+ * - application-payment-test.properties 설정 사용
+ */
 @SpringBootTest
+@ActiveProfiles("payment-test")     // application-payment-test.properties 설정 사용
 class PaymentSystemApplicationTest {
-    @Autowired
-    WalletRepository walletRepository;
+    // ===== 의존성 주입 =====
+    @Autowired WalletRepository walletRepository;   // 지갑 리포지토리
 
+    // 스프링 컨텍스트 로딩 및 기본 리포지토리 동작 확인
     @Test
     void contextLoads() {
         System.out.println(walletRepository.findAll());

--- a/src/test/java/com/projectboard/payment/WalletServiceIntgTest.java
+++ b/src/test/java/com/projectboard/payment/WalletServiceIntgTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,17 +25,27 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+/**
+ * WalletService 통합 테스트
+ * - 실제 DB와 스프링 컨텍스트를 사용하여 지갑 서비스의 주요 기능을 검증
+ * - 지갑 생성, 잔액 충전, 동시성 테스트를 통해 멱등성 및 데이터 무결성 보장 확인
+ * - application-payment-test.yml 설정 사용
+ */
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
+@ActiveProfiles("payment-test") // application-payment-test.yml 설정 사용
 public class WalletServiceIntgTest {
+    // ===== 의존성 주입 =====
+    // SUT
+    @Autowired WalletService walletService;                 // 실제 지갑 서비스
+    // 의존성 주입
+    @Autowired WalletRepository walletRepository;           // 실제 리포지토리
 
-    @Autowired
-    WalletService walletService;
-    @Autowired
-    WalletRepository walletRepository;
-
+    // 각 테스트 격리
     @AfterEach
-    void tearDown() { walletRepository.deleteAll(); } // 각 테스트 격리
+    void tearDown() {
+        walletRepository.deleteAll();         // 트랜잭션이 지갑에 종속되어 있으므로, 지갑부터 삭제해야 함
+    }
 
     @Test
     @Transactional


### PR DESCRIPTION
# PR: 결제 시스템 - 통합 테스트 전용 application-payment-test.yaml 설정 분리 및 적용

## 작업 개요
- 통합 테스트 환경을 위한 별도 설정 파일(`application-payment-test.yml`)을 분리하고,
  각 통합 테스트에서 해당 프로파일을 적용하도록 수정하였습니다.
- 실제 운영/개발 환경 설정과 테스트 환경을 분리하여 안정성을 확보하고,
  로컬/CI 환경에서 일관된 테스트 실행이 가능하도록 개선하였습니다.

## 주요 변경 사항
1. **application-payment-test.yml 추가**
   - 로컬 모의 PG 서버(`http://localhost:8080/pg-mock`)를 기본으로 사용
   - Postman mock 서버 URL을 주석 처리하여 필요 시 Timeout 테스트에 활용 가능
   - JPA/Flyway/logging 설정을 테스트 환경에 맞게 조정

2. **PaymentSystemApplicationTest**
   - `@ActiveProfiles("payment-test")` 적용
   - 클래스 주석 보강: 스프링 컨텍스트 로딩 및 리포지토리 동작 확인 목적임을 명시

3. **WalletServiceIntgTest**
   - `@ActiveProfiles("payment-test")` 적용
   - 실제 DB 연동 및 동시성/멱등성 보장 검증 주석 보강

4. **PaymentGatewayServiceIntgTest**
   - `@ActiveProfiles("payment-test")` 적용
   - 실제 PG 연동 테스트는 `@Disabled` 처리 (로컬 수동 실행 전용)
   - Mock/Local 서버 기반으로 안전하게 테스트할 수 있도록 개선

## 완료 조건
- [x] 모든 통합 테스트 클래스에서 `payment-test` 프로파일이 정상 적용됨  
- [x] PaymentSystemApplicationTest 실행 시 스프링 컨텍스트 정상 로딩 확인  
- [x] WalletServiceIntgTest에서 지갑 생성/동시성 테스트 정상 통과  
- [x] PaymentGatewayServiceIntgTest가 기본적으로는 실행되지 않으며(`@Disabled`), 필요 시 로컬에서만 수동 실행 가능  

## 비고
- 운영/개발 환경 설정과 테스트 환경을 명확히 분리하여, CI/CD 파이프라인에서 테스트 안정성을 높였습니다.