### PR TITLE
[#38] 결제 시스템 - Order–Donation–Wallet 연관 관계 정리, 중복 필드 제거, 관련 코드 전반 리팩터링

### DIFF
--- a/src/main/java/com/projectboard/payment/checkout/CheckoutController.java
+++ b/src/main/java/com/projectboard/payment/checkout/CheckoutController.java
@@ -6,13 +6,17 @@ import com.projectboard.payment.processing.PaymentProcessingService;
 import com.projectboard.payment.order.OrderStatus;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -29,46 +33,86 @@ public class CheckoutController {
     private final PaymentProcessingService paymentProcessingService;    // 결제 처리 서비스
 
     /**
-     * 주문 생성 페이지
+     * 주문 페이지
      * - 사용자가 결제할 금액과 주문 ID를 확인하는 화면.
+     * - 멱등성 보장을 위한 requestId 처리 포함.
      * - templates/payment/order.html 뷰를 렌더링.
+     *
+     * @param userId        사용자 ID
+     * @param amountQS     결제 금액 (문자열)
+     * @param donationId    후원 ID
+     * @param donationName  후원 이름
+     * @param requestIdFromQS 멱등성 보장을 위한 requestId (선택적)
+     * @param model         뷰 모델
+     * @return 주문 페이지 뷰 이름
      */
     @GetMapping("/order")
     public String order(
             @RequestParam("userId") Long userId,
-            @RequestParam("amount") String amount,
+            @RequestParam("amount") String amountQS,
             @RequestParam("donationId") Long donationId,
             @RequestParam("donationName") String donationName,
             @RequestParam(value = "requestId", required = false) String requestIdFromQS,
             Model model
     ) {
-        Order order;
-        if (requestIdFromQS != null) {
-            order = orderRepository.findByRequestId(requestIdFromQS);
-        } else {
+        // 1. 주문 조회 또는 생성
+        // Order 객체 선언
+        final Order order;
+
+        // 1) requestId가 있으면 해당 주문 조회
+        // 멱등성 보장을 위한 requestId 처리
+        if (StringUtils.hasText(requestIdFromQS)) {
+            // requestId로 주문 조회
+            order = Optional.ofNullable(orderRepository.findByRequestId(requestIdFromQS))                   // 주문 조회
+                    .orElseThrow(() -> new ResponseStatusException(                                         // 주문이 존재하지 않으면 예외 발생
+                            HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다. requestId=" + requestIdFromQS));    // 404 Not Found 응답
+
+            // 주문의 userId와 요청한 userId가 일치하는지 확인
+            if (!order.getUserId().equals(userId)) {
+                // 일치하지 않으면 403 Forbidden 응답
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "주문 소유자가 일치하지 않습니다.");
+            }
+        }
+        // 2) requestId가 없으면 새 주문 생성
+        else {
+            // amount 파싱
+            BigDecimal amount;
+            // amountQS가 올바른 형식인지 확인
+            try {
+                // BigDecimal로 변환 시도
+                amount = new BigDecimal(amountQS);
+            } catch (NumberFormatException e) { // 변환 실패 시 예외 처리
+                // 잘못된 형식 예외 발생
+                // 400 Bad Request 응답
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "amount 형식이 올바르지 않습니다.");
+            }
+
+            // 새 주문 생성
             order = new Order();
-            order.setAmount(new BigDecimal(amount));
-            order.setUserId(userId);
-            order.setRequestId(java.util.UUID.randomUUID().toString());
-            order.waitStatus();
-            orderRepository.save(order);
+            order.setAmount(amount);                                                        // 주문 금액 설정
+            order.setUserId(userId);                                                        // 사용자 ID 설정
+            order.setRequestId(java.util.UUID.randomUUID().toString());                     // 멱등성 보장을 위한 requestId 생성
+            order.waitStatus();                                                             // 주문 상태를 WAIT로 설정
+            orderRepository.save(order);                                                    // 주문 저장
         }
 
-        // 모델에 주문 정보 추가
-        model.addAttribute("donationName", donationName);                       // 후원 아이템 이름
-        model.addAttribute("requestId", order.getRequestId());                  // 고유 주문 ID
-        model.addAttribute("amount", amount);                                   // 후원 금액
-        model.addAttribute("customerKey", "customerKey-" + userId); // 고객 키 (예: 사용자 ID 기반)
+        // 2. 모델에 주문 정보 추가
+        model.addAttribute("donationName", donationName);                       // 후원 이름
+        model.addAttribute("requestId", order.getRequestId());                  // 주문 요청 ID
+        model.addAttribute("amount", order.getAmount().toPlainString());        // 주문 금액
+        model.addAttribute("customerKey", "customerKey-" + userId);  // 고객 키 (예: "customerKey-1")
 
-        // 주문 페이지 뷰 이름 반환
+        // 3. 주문 페이지 뷰 렌더링
         // templates/payment/order.html
         return "payment/order";
     }
 
     /**
-     * 주문 요청 페이지
-     * - 사용자가 결제할 금액과 주문 ID를 확인하는 화면.
+     * 주문 요청 완료 페이지
+     * - 사용자가 결제를 요청한 후 보여지는 페이지.
      * - templates/payment/order-requested.html 뷰를 렌더링.
+     *
+     * @return 주문 요청 완료 페이지 뷰 이름
      */
     @GetMapping("/order-requested")
     public String orderRequested() {
@@ -77,8 +121,10 @@ public class CheckoutController {
 
     /**
      * 결제 실패 페이지
-     * - Toss 결제 실패 후 redirect 될 URL
-     * - templates/payment/fail.html 렌더링
+     * - Toss 결제 실패 후 리다이렉트될 URL
+     * - templates/payment/fail.html 뷰를 렌더링
+     *
+     * @return 결제 실패 페이지 뷰 이름
      */
     @GetMapping("/fail")
     public String fail() {
@@ -86,10 +132,13 @@ public class CheckoutController {
     }
 
     /**
-     * 결제 승인 API 호출
-     * - 프론트엔드(success.html)에서 결제 성공 시, toss에서 받은 결제 정보를 서버로 전달함.
-     * - 서버는 이 데이터를 Toss Payments API로 전달하여 결제를 "승인(confirm)"함.
-     * - 이 과정을 통해 결제가 최종적으로 확정되고, DB에 내역을 저장할 수 있음.
+     * 결제 승인 API
+     * - 사용자가 결제를 승인할 때 호출되는 엔드포인트.
+     * - 주문 상태를 REQUESTED로 변경하고, 결제 승인 요청을 처리.
+     *
+     * @param confirmRequest 결제 승인 요청 데이터
+     * @return 성공 시 200 OK 응답
+     * @throws Exception 결제 처리 중 예외 발생 시
      */
     @RequestMapping(method = RequestMethod.POST, value = "/confirm")
     public ResponseEntity<Object> confirmPayment(@RequestBody ConfirmRequest confirmRequest) throws Exception {

--- a/src/main/java/com/projectboard/payment/checkout/CheckoutController.java
+++ b/src/main/java/com/projectboard/payment/checkout/CheckoutController.java
@@ -16,60 +16,17 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
- * 체크아웃 컨트롤러
- * - 주문 생성, 결제 페이지 진입, 결제 승인 처리 등을 담당.
- * - 결제 성공 및 실패 페이지 렌더링.
+ * CheckoutController
+ * - 결제 관련 페이지 렌더링 및 결제 승인 API 제공
+ * - 주문 생성, 결제 승인, 결제 실패 페이지 등 처리
  */
 @Slf4j
 @Controller
 @AllArgsConstructor
 public class CheckoutController {
-    /**
-    TODO:
-    1. checkout 페이지 렌더링 시 orderId 를 만들어줘야 한다.
-        - orderId 는 고유해야 한다. (ex: UUID)
-        - 결제 성공 후 주문 내역을 조회할 때 사용된다.
-
-    2. PG 와 주고 받은 데이터를 저장
-        - 요청 -> 승인
-        - 요청 데이터 저장
-        - 승인 데이터 저장
-
-    3. 후원 결제 API 연동
-        - 후원 결제 시, 후원자 정보 및 후원 금액을 함께 처리.
-        - 후원 내역을 데이터베이스에 저장.
-
-    4. 결제 내역 저장 및 관리 기능 구현 (선택 사항)
-        - 결제 내역을 데이터베이스에 저장.
-        - 사용자가 자신의 결제 내역을 조회할 수 있는 기능 추가.
-        - 관리자가 결제 내역을 조회할 수 있는 기능 추가.
-
-    5. 환불 처리 기능 구현 (선택 사항)
-        - 환불 요청 시, 토스페이먼츠 환불 API 호출 구현.
-        - 환불 내역을 데이터베이스에 저장 및 관리.
-        - 환불 상태를 사용자에게 알림.
-
-    6. UI/UX 개선 (선택 사항)
-        - 후원 페이지 및 결제 페이지 디자인 개선.
-        - 마이페이지에서 후원 및 결제 내역 확인 기능 추가.
-        - 관리자 페이지에서 결제 및 환불 내역 관리 기능 추가.
-
-    7. 에러 처리
-        - API 호출 실패 시, 적절한 에러 메시지 반환.
-        - 결제 실패 시, 사용자에게 알림 및 재시도 옵션 제공.
-        - 로그를 통해 에러 원인 분석 및 추적 가능하도록 구현.
-
-    8. 테스트 및 검증
-        - 다양한 결제 시나리오에 대한 테스트 케이스 작성.
-        - 실제 결제 환경에서의 검증.
-
-    9. 보안 강화
-        - 결제 관련 API 호출 시, 인증 및 권한 부여 구현.
-        - 민감한 정보(예: 시크릿 키) 보호.
-     */
-
-    private final OrderRepository orderRepository;
-    private final PaymentProcessingService paymentProcessingService;
+    // ===== 의존성 주입 =====
+    private final OrderRepository orderRepository;                      // 주문 리포지토리
+    private final PaymentProcessingService paymentProcessingService;    // 결제 처리 서비스
 
     /**
      * 주문 생성 페이지
@@ -82,24 +39,29 @@ public class CheckoutController {
             @RequestParam("amount") String amount,
             @RequestParam("donationId") Long donationId,
             @RequestParam("donationName") String donationName,
+            @RequestParam(value = "requestId", required = false) String requestIdFromQS,
             Model model
     ) {
-        Order order = new Order();
-        order.setAmount(new BigDecimal(amount));
-        order.setDonationId(donationId);
-        order.setDonationName(donationName);
-        order.setUserId(userId);
-        order.setRequestId(UUID.randomUUID().toString());
-        order.setStatus(OrderStatus.WAIT);
-        order.setCreatedAt(LocalDateTime.now());
-        order.setUpdatedAt(LocalDateTime.now());
-        orderRepository.save(order);
+        Order order;
+        if (requestIdFromQS != null) {
+            order = orderRepository.findByRequestId(requestIdFromQS);
+        } else {
+            order = new Order();
+            order.setAmount(new BigDecimal(amount));
+            order.setUserId(userId);
+            order.setRequestId(java.util.UUID.randomUUID().toString());
+            order.waitStatus();
+            orderRepository.save(order);
+        }
 
-        model.addAttribute("donationName", donationName);
-        model.addAttribute("requestId", order.getRequestId());
-        model.addAttribute("amount", amount);
-        model.addAttribute("customerKey", "customerKey-" + userId);
+        // 모델에 주문 정보 추가
+        model.addAttribute("donationName", donationName);                       // 후원 아이템 이름
+        model.addAttribute("requestId", order.getRequestId());                  // 고유 주문 ID
+        model.addAttribute("amount", amount);                                   // 후원 금액
+        model.addAttribute("customerKey", "customerKey-" + userId); // 고객 키 (예: 사용자 ID 기반)
 
+        // 주문 페이지 뷰 이름 반환
+        // templates/payment/order.html
         return "payment/order";
     }
 

--- a/src/main/java/com/projectboard/payment/donation/Donation.java
+++ b/src/main/java/com/projectboard/payment/donation/Donation.java
@@ -20,7 +20,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Entity
 @Builder
-@Table(name = "donation")
+@Table(
+        name = "donation",                                                                          // 테이블명 지정
+        uniqueConstraints = @UniqueConstraint(name = "uk_donation_order", columnNames = "order_id") // order_id 컬럼에 고유 제약 조건 설정
+)
 public class Donation {
     // ===== 기본 필드 =====
     @Id                                     // 기본 키, 자동 생성
@@ -63,14 +66,20 @@ public class Donation {
     @JoinColumn(name = "wallet_id")                                             // 외래 키 설정
     private Wallet wallet;                                                      // 후원자 지갑 정보 (포인트 후원 시 사용)
 
-    /** 후원과 주문의 연관 관계
-     * - PG 직접 결제 시 사용되는 주문과의 일대일 단방향 연관 관계 설정.
+    /**
+     * 후원과 주문의 연관 관계
+     * - 직접 결제 완료 시 사용되는 주문과의 일대일 단방향 연관 관계 설정.
+     * - Donation가 주인, Order가 종속.
+     * - 직접 후원 시에만 주문이 생성되므로
      * - 포인트 후원 시에는 null이 될 수 있도록 optional=true로 설정.
      * - 모든 영속성 전이 설정(CascadeType.ALL)하여 후원 엔티티가 저장/삭제될 때 연관된 주문 엔티티도 함께 처리.
+     * - order_id 컬럼에 고유 제약 조건(Unique Constraint) 설정하여 1:1 관계 보장.
      */
-    // PG 직접 결제 시 사용되는 주문과의 일대일 단방향 연관 관계 설정
     @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL)
-    @JoinColumn(name= "order_id")                                               // 외래 키 설정
+    @JoinColumn(
+            name= "order_id",                                                   // 외래 키 설정
+            foreignKey = @ForeignKey(name = "fk_donation_order")                // 외래 키 제약 조건 이름 설정
+    )
     private Order order;                                                        // 연관된 주문 (포인트 후원 시 null, 직접 후원 시 주문 정보)
 
     /**
@@ -138,8 +147,8 @@ public class Donation {
     }
 
     // updatedAt 자동 갱신
-    @PreUpdate void
-    onUpdate() { this.updatedAt = LocalDateTime.now(); }
+    @PreUpdate
+    void onUpdate() { this.updatedAt = LocalDateTime.now(); }
 
     // ===== 도메인 규칙 =====
     // 후원 완료 처리 메서드
@@ -154,7 +163,7 @@ public class Donation {
     }
 
     // ===== 연관 관계를 위한 Setter =====
-    // 연관된 지갑 설정 메서드
+    // 연관된 주문 설정 메서드
     public void setOrder(Order order) { this.order = order; }
 
     // 연관된 트랜잭션 설정 메서드

--- a/src/main/java/com/projectboard/payment/donation/Donation.java
+++ b/src/main/java/com/projectboard/payment/donation/Donation.java
@@ -1,5 +1,6 @@
 package com.projectboard.payment.donation;
 
+import com.projectboard.payment.order.Order;
 import com.projectboard.payment.transaction.Transaction;
 import com.projectboard.payment.wallet.Wallet;
 import jakarta.persistence.*;
@@ -10,20 +11,18 @@ import java.time.LocalDateTime;
 
 /**
  * 후원 엔티티
- * - 사용자 후원 정보를 저장.
- * - 후원 아이템, 유형, 상태 및 관련 메타데이터 포함.
- * - Wallet 및 Transaction과의 연관 관계 설정.
+ * - 사용자의 후원 내역을 저장.
+ * - 후원 아이템, 금액, 유형, 상태 및 관련 메타데이터 포함.
+ * - Wallet, Order, Transaction과의 연관 관계 설정.
  */
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 @Entity
-@Getter
-@Setter
 @Builder
 @Table(name = "donation")
 public class Donation {
-
+    // ===== 기본 필드 =====
     @Id                                     // 기본 키, 자동 생성
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;                        // 후원 ID (기본 키)
@@ -54,18 +53,37 @@ public class Donation {
 
     private String errorMessage;            // 후원 실패 시 에러 메시지
 
-    // ===== Wallet 연관 관계 =====
-    @ManyToOne(fetch = FetchType.LAZY, optional = true) // 다대일 단방향 연관 관계 (포인트 후원 시 사용, 직접 후원 시 null). optional=true로 설정하여 null 허용 (연결 관계 없어도 됨)
-    @JoinColumn(name = "wallet_id")                     // 외래 키 설정
-    private Wallet wallet;                              // 후원자 지갑 정보 (포인트 후원 시 사용)
+    // ===== 연관 관계 설정 =====
+    /**
+     * 후원과 지갑의 연관 관계
+     * - 포인트 후원 시 사용되는 지갑과의 다대일 단방향 연관 관계 설정.
+     * - 직접 후원 시에는 null이 될 수 있도록 optional=true로 설정.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "wallet_id")                                             // 외래 키 설정
+    private Wallet wallet;                                                      // 후원자 지갑 정보 (포인트 후원 시 사용)
 
-    // ===== Transaction 연관 관계 =====
-    @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL) // 일대일 단방향 연관 관계 (직접 후원 시 사용, 포인트 후원 시 null). 모든 영속성 전이 설정
-    @JoinColumn(name = "transaction_id")                                          // 외래 키 설정
-    private Transaction transaction;                                              // 연관된 트랜잭션 (포인트 후원 시 null, 직접 후원 시 결제 트랜잭션)
+    /** 후원과 주문의 연관 관계
+     * - PG 직접 결제 시 사용되는 주문과의 일대일 단방향 연관 관계 설정.
+     * - 포인트 후원 시에는 null이 될 수 있도록 optional=true로 설정.
+     * - 모든 영속성 전이 설정(CascadeType.ALL)하여 후원 엔티티가 저장/삭제될 때 연관된 주문 엔티티도 함께 처리.
+     */
+    // PG 직접 결제 시 사용되는 주문과의 일대일 단방향 연관 관계 설정
+    @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL)
+    @JoinColumn(name= "order_id")                                               // 외래 키 설정
+    private Order order;                                                        // 연관된 주문 (포인트 후원 시 null, 직접 후원 시 주문 정보)
+
+    /**
+     * 후원과 트랜잭션의 연관 관계
+     * - 직접 결제 완료 시 사용되는 트랜잭션과의 일대일 단방향 연관 관계 설정.
+     * - 포인트 후원 시에는 null이 될 수 있도록 optional=true로 설정.
+     * - 모든 영속성 전이 설정(CascadeType.ALL)하여 후원 엔티티가 저장/삭제될 때 연관된 트랜잭션 엔티티도 함께 처리.
+     */
+    @OneToOne(fetch = FetchType.LAZY, optional = true, cascade = CascadeType.ALL)
+    @JoinColumn(name = "transaction_id")                                        // 외래 키 설정
+    private Transaction transaction;                                            // 연관된 트랜잭션 (포인트 후원 시 null, 직접 후원 시 결제 트랜잭션)
 
     // ===== Enum 정의 =====
-
     /**
      * 후원 아이템
      * - BOOK: 교재 (10,000원)
@@ -111,5 +129,35 @@ public class Donation {
     public enum DonationStatus {
         REQUESTED, COMPLETED, FAILED;
     }
+
+    // createdAt, updatedAt 자동 설정
+    @PrePersist
+    void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    // updatedAt 자동 갱신
+    @PreUpdate void
+    onUpdate() { this.updatedAt = LocalDateTime.now(); }
+
+    // ===== 도메인 규칙 =====
+    // 후원 완료 처리 메서드
+    public void markCompleted() {
+        this.donationStatus = DonationStatus.COMPLETED; // 후원 완료로 상태 변경
+    }
+
+    // 후원 실패 처리 메서드
+    public void markFailed(String message) {
+        this.donationStatus = DonationStatus.FAILED;    // 후원 실패로 상태 변경
+        this.errorMessage = message;                    // 실패 사유 메시지 설정
+    }
+
+    // ===== 연관 관계를 위한 Setter =====
+    // 연관된 지갑 설정 메서드
+    public void setOrder(Order order) { this.order = order; }
+
+    // 연관된 트랜잭션 설정 메서드
+    public void setTransaction(Transaction tx) { this.transaction = tx; }
 
 }

--- a/src/main/java/com/projectboard/payment/donation/DonationController.java
+++ b/src/main/java/com/projectboard/payment/donation/DonationController.java
@@ -1,15 +1,25 @@
 package com.projectboard.payment.donation;
 
 import com.projectboard.payment.checkout.ConfirmRequest;
+import com.projectboard.payment.order.Order;
+import com.projectboard.payment.order.OrderRepository;
+import com.projectboard.payment.order.OrderStatus;
+import com.projectboard.payment.processing.PaymentProcessingService;
 import com.projectboard.payment.wallet.WalletService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * DonationController
@@ -22,54 +32,77 @@ import java.util.List;
 @RequestMapping("/api/donations")
 public class DonationController {
     // ===== 의존성 주입 =====
-    private final DonationService donationService; // 후원 서비스
-    private final WalletService walletService;     // 지갑 서비스
+    private final DonationService donationService;                      // 후원 서비스
+    private final PaymentProcessingService paymentProcessingService;    // 결제 처리 서비스
 
     /**
-     * 포인트로 후원
-     * - 사용자 ID와 후원 아이템을 받아 포인트로 후원 처리
-     * - 후원 성공 시 Donation 객체 반환
+     * 포인트 후원 API
+     * - 사용자 ID와 후원 아이템을 받아 포인트 후원 처리
+     * - 후원 성공 시 성공 메시지 반환
+     *
      * @param userId 후원자 사용자 ID
      * @param item 후원 아이템
-     * @return 후원 기록 객체
+     * @return 성공 메시지
      */
-    @PostMapping("/api/point")
+    @PostMapping("/point")
     @ResponseBody
-    public Donation donateWithPoint(
-            @RequestParam Long userId,
-            @RequestParam String item
+    public ResponseEntity<String> donateWithPoint(
+            @RequestParam("userId") Long userId,
+            @RequestParam("item") Donation.DonationItem item
     ) {
         // 후원 서비스 호출
-        return donationService.donateWithPoint(userId, Donation.DonationItem.valueOf(item));
+        donationService.donateWithPoint(userId, item);
+
+        // 성공 메시지 반환
+        return ResponseEntity.ok("포인트 후원 성공");
     }
 
     /**
-     * 직접 결제 후원
-     * - 사용자 ID, 결제 승인 요청 정보, 후원 아이템을 받아 직접 결제 후원 처리
-     * - 후원 성공 시 Donation 객체 반환
+     * 직접 결제 후원 API
+     * - 사용자 ID와 후원 아이템을 받아 직접 결제 후원 처리
+     * - 후원 준비 후 결제 페이지로 이동할 URL 반환
+     *
      * @param userId 후원자 사용자 ID
+     * @param item 후원 아이템
+     * @return 결제 페이지로 이동할 URL
+     */
+    @PostMapping("/direct")
+    @ResponseBody
+    public ResponseEntity<String> donateWithDirectPayment(
+            @RequestParam("userId") Long userId,
+            @RequestParam("item") Donation.DonationItem item
+    ) {
+        // 서비스에서 Donation(REQUESTED, DIRECT) + Order(WAIT) 생성 후 order 화면으로 이동할 쿼리스트링 생성
+        String redirectUrl = donationService.prepareDirectDonation(userId, item);
+
+        return ResponseEntity.ok(redirectUrl);
+    }
+
+    /**
+     * 후원 결제 승인 API
+     * - PG사로부터 결제 승인 요청을 받아 처리
+     * - 결제 처리 서비스 호출 후 성공 메시지 반환
+     *
      * @param confirmRequest 결제 승인 요청 정보
-     * @param item 후원 아이템
-     * @return 후원 기록 객체
+     * @return 성공 메시지
      */
-    @PostMapping("/api/direct")
-    @ResponseBody
-    public Donation donateWithPayment(
-            @RequestParam Long userId,
-            @RequestBody ConfirmRequest confirmRequest,
-            @RequestParam String item
-    ) {
-        // 후원 서비스 호출
-        return donationService.donateWithPayment(userId, confirmRequest, Donation.DonationItem.valueOf(item));
+    @PostMapping("/confirm")
+    public ResponseEntity<Object> confirmDonation(@RequestBody ConfirmRequest confirmRequest) {
+        // 결제 처리 서비스 호출
+        paymentProcessingService.createPayment(confirmRequest);
+
+        // 성공 메시지 반환
+        return ResponseEntity.ok("후원 결제 승인 성공");
     }
 
     /**
-     * 내 후원 내역 조회
+     * 내 후원 내역 조회 API
      * - 인증된 사용자의 후원 내역을 조회하여 반환
+     *
      * @param user 인증된 사용자 정보
      * @return 후원 내역 리스트
      */
-    @GetMapping("/api/donations/my")
+    @GetMapping("/my")
     public ResponseEntity<List<DonationResponse>> getMyDonations(@AuthenticationPrincipal User user) {
         // 후원 서비스 호출
         // user.getUsername()은 String 타입이므로 Long으로 변환 필요

--- a/src/main/java/com/projectboard/payment/donation/DonationController.java
+++ b/src/main/java/com/projectboard/payment/donation/DonationController.java
@@ -1,25 +1,15 @@
 package com.projectboard.payment.donation;
 
 import com.projectboard.payment.checkout.ConfirmRequest;
-import com.projectboard.payment.order.Order;
-import com.projectboard.payment.order.OrderRepository;
-import com.projectboard.payment.order.OrderStatus;
 import com.projectboard.payment.processing.PaymentProcessingService;
-import com.projectboard.payment.wallet.WalletService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigDecimal;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * DonationController
@@ -50,8 +40,13 @@ public class DonationController {
             @RequestParam("userId") Long userId,
             @RequestParam("item") Donation.DonationItem item
     ) {
-        // 후원 서비스 호출
-        donationService.donateWithPoint(userId, item);
+        // 서비스에서 Donation(REQUESTED, POINT) 생성 및 포인트 차감 처리
+        Donation donation = donationService.donateWithPoint(userId, item);
+
+        // 후원 실패 시 에러 메시지 반환
+        if (donation.getDonationStatus() == Donation.DonationStatus.FAILED) {
+            return ResponseEntity.badRequest().body("포인트 후원 실패");
+        }
 
         // 성공 메시지 반환
         return ResponseEntity.ok("포인트 후원 성공");

--- a/src/main/java/com/projectboard/payment/donation/DonationRepository.java
+++ b/src/main/java/com/projectboard/payment/donation/DonationRepository.java
@@ -1,18 +1,23 @@
 package com.projectboard.payment.donation;
 
+import com.projectboard.payment.order.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * DonationRepository
- * - 후원 관련 데이터베이스 작업을 처리하는 리포지토리 인터페이스.
+ * - 후원 내역을 관리하는 리포지토리 인터페이스.
  * - JpaRepository를 상속하여 기본 CRUD 기능 제공.
+ * - 사용자 ID로 후원 내역 조회 및 주문으로 후원 내역 조회 기능 포함.
  */
 @Repository
 public interface DonationRepository extends JpaRepository<Donation, Long> {
-
     // 사용자 ID로 후원 내역 조회 (최신순)
     List<Donation> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 주문으로 후원 내역 조회
+    Optional<Donation> findByOrder(Order order);
 }

--- a/src/main/java/com/projectboard/payment/donation/DonationService.java
+++ b/src/main/java/com/projectboard/payment/donation/DonationService.java
@@ -3,6 +3,9 @@ package com.projectboard.payment.donation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.projectboard.payment.checkout.ConfirmRequest;
 import com.projectboard.payment.external.PaymentGatewayService;
+import com.projectboard.payment.order.Order;
+import com.projectboard.payment.order.OrderRepository;
+import com.projectboard.payment.order.OrderStatus;
 import com.projectboard.payment.transaction.Transaction;
 import com.projectboard.payment.transaction.TransactionRepository;
 import com.projectboard.payment.transaction.TransactionService;
@@ -35,17 +38,14 @@ public class DonationService {
     private final PaymentGatewayService paymentGatewayService;      // 외부 결제 게이트웨이 서비스
     private final TransactionService transactionService;            // 거래 서비스
     private final TransactionRepository transactionRepository;      // 거래 리포지토리
-
     private final ObjectMapper objectMapper;                        // JSON 변환기
+    private final OrderRepository orderRepository;
 
     /**
-     * 포인트로 후원
-     * - 사용자 ID와 후원 아이템을 받아 포인트로 후원 처리
-     * - 후원 성공 시 Donation 객체 반환
-     * - 잔액 부족 시 후원 실패 기록 저장 및 예외 발생
-     * - 지갑 조회, 잔액 확인, 잔액 차감, 거래 기록 생성, 후원 기록 생성 및 저장 순으로 처리
+     * 포인트 후원
+     * - 사용자 ID와 후원 아이템을 받아 포인트 후원 처리
+     * - 지갑 조회, 잔액 확인, 잔액 부족 시 실패 기록 저장, 잔액 충분 시 차감 및 후원 기록 저장 순으로 처리
      * - 트랜잭션 처리 보장 (모든 작업이 성공해야 커밋, 하나라도 실패하면 롤백)
-     * - 후원 아이템에 따른 가격 책정
      *
      * @param userId 후원자 사용자 ID
      * @param item 후원 아이템
@@ -54,6 +54,7 @@ public class DonationService {
     @Transactional
     public Donation donateWithPoint(Long userId, Donation.DonationItem item) {
         // 1. 지갑 조회
+        // 사용자 ID로 지갑 조회, 없으면 예외 발생
         Wallet wallet = walletRepository.findWalletByUserId(userId)
                 .orElseThrow((() -> new IllegalArgumentException("지갑이 존재하지 않습니다. userId=" + userId)));
 
@@ -64,60 +65,137 @@ public class DonationService {
         // 2. 잔액 부족 처리
         // 잔액 부족 시, 후원 실패 기록 저장 후 예외 던지기
         if (wallet.getBalance().compareTo(price) < 0) {
-
             // 실패한 후원 기록 생성
-            Donation failedDonation = Donation.builder()
+            Donation failed = Donation.builder()                        // 후원 엔티티 생성
                     .userId(userId)                                     // 후원자 ID
                     .donationItem(item)                                 // 후원 아이템
                     .amount(price)                                      // 후원 금액
                     .donationType(Donation.DonationType.POINT)          // 포인트 후원
                     .donationStatus(Donation.DonationStatus.FAILED)     // 실패 처리
+                    .errorMessage("잔액 부족")                            // 에러 메시지 저장
                     .createdAt(java.time.LocalDateTime.now())
                     .updatedAt(java.time.LocalDateTime.now())
                     .build();                                           // 빌더 패턴으로 후원 엔티티 생성
 
             // 실패한 후원 기록 저장
-            donationRepository.save(failedDonation);
-
-            // 예외 던지기
-            throw new IllegalArgumentException("잔액이 부족합니다. balance=" + wallet.getBalance() + ", price=" + price);
+            return donationRepository.save(failed);
         }
 
         // 3. 잔액 충분 시, 후원 처리
         // 잔액 차감 및 지갑 저장
-        wallet.setBalance(wallet.getBalance().subtract(price));     // balance - price
+        wallet.spend(price);                                            // balance - price
         walletRepository.save(wallet);
-
-        // 트랜잭션 생성 및 저장
-        Transaction tx = transactionService.createPointDonationTransaction(
-                userId,
-                wallet.getId(),
-                price
-        );
 
         // 후원 기록 생성
         // 후원 엔티티 생성
-        Donation donation = Donation.builder()
-                .userId(userId)                                     // 후원자 ID
-                .donationItem(item)                                 // 후원 아이템
-                .amount(price)                                      // 후원 금액
-                .donationType(Donation.DonationType.POINT)          // 포인트 후원
-                .donationStatus(Donation.DonationStatus.COMPLETED)  // 즉시 완료 처리
+        Donation donation = Donation.builder()                          // 후원 엔티티 생성
+                .userId(userId)                                         // 후원자 ID
+                .donationItem(item)                                     // 후원 아이템
+                .amount(price)                                          // 후원 금액
+                .donationType(Donation.DonationType.POINT)              // 포인트 후원
+                .donationStatus(Donation.DonationStatus.COMPLETED)      // 즉시 완료 처리
+                .wallet(wallet)                                         // 지갑 정보 저장
                 .createdAt(java.time.LocalDateTime.now())
                 .updatedAt(java.time.LocalDateTime.now())
-                .build();                                           // 빌더 패턴으로 후원 엔티티 생성
+                .build();                                               // 빌더 패턴으로 후원 엔티티 생성
 
         // 후원 기록 저장
         return donationRepository.save(donation);
     }
 
     /**
-     * 직접 결제로 후원
-     * - 사용자 ID, 결제 확인 요청, 후원 아이템을 받아 직접 결제 후원 처리
-     * - PG 승인 요청 및 거래 기록 생성
-     * - 후원 성공 시 Donation 객체 반환
+     * 직접 결제 후원 준비
+     * - 사용자 ID와 후원 아이템을 받아 직접 결제 후원 준비
+     * - 주문 생성, 후원 기록 생성 및 저장, 결제 페이지 URL 생성 순으로 처리
+     *
+     * @param userId 후원자 사용자 ID
+     * @param item 후원 아이템
+     * @return 결제 페이지로 이동할 URL
+     */
+    @Transactional
+    public String prepareDirectDonation(Long userId, Donation.DonationItem item) {
+        // 후원 아이템에 따른 가격
+        BigDecimal price = item.getPrice();
+
+        // 주문 생성
+        Order order = Order.builder()
+                .userId(userId)
+                .amount(price)
+                .requestId(java.util.UUID.randomUUID().toString())
+                .status(OrderStatus.WAIT)
+                .build();
+        orderRepository.save(order);
+
+        // Donation(REQUESTED, DIRECT) 생성 + Order 연결
+        Donation donation = Donation.builder()
+                .userId(userId)
+                .donationItem(item)
+                .amount(price)
+                .donationType(Donation.DonationType.DIRECT)
+                .donationStatus(Donation.DonationStatus.REQUESTED)
+                .order(order)
+                .build();
+
+        // 후원 기록 저장
+        Donation savedDonation = donationRepository.save(donation);
+
+        // 결제 페이지로 이동할 URL 생성
+        // (order 화면은 주문명/금액/요청ID만 필요)
+        String donationName = item.name(); // 화면에는 한글 라벨을 쓰면 좋으면 프런트에서 표시
+        return "/order?userId=" + userId
+                + "&amount=" + price
+                + "&donationId=" + savedDonation.getId()     // 필요하면 화면에서 사용
+                + "&donationName=" + java.net.URLEncoder.encode(donationName, java.nio.charset.StandardCharsets.UTF_8)
+                + "&requestId=" + order.getRequestId();
+    }
+
+    /**
+     * 직접 결제 후원 완료 처리
+     * - 결제 확인 요청 정보를 받아 직접 결제 후원 완료 처리
+     * - 중복 방지, PG 승인, 주문 상태 변경, 연결된 Donation 조회, 트랜잭션 기록 생성, Donation 완료 처리 순으로 처리
+     * - 트랜잭션 처리 보장 (모든 작업이 성공해야 커밋, 하나라도 실패하면 롤백)
+     *
+     * @param confirmRequest 결제 확인 요청 정보
+     */
+    @Transactional
+    public void completeDirectDonation(ConfirmRequest confirmRequest) {
+        // 중복 방지
+        if (transactionRepository.existsByOrderId(confirmRequest.orderId())) {
+            return;
+        }
+
+        // PG 승인
+        paymentGatewayService.confirm(confirmRequest);
+
+        // 주문 조회 및 상태 변경
+        Order order = orderRepository.findByRequestId(confirmRequest.orderId());
+        order.approved();
+        orderRepository.save(order);
+
+        // 연결된 Donation 조회
+        Donation donation = donationRepository.findByOrder(order)
+                .orElseThrow(() -> new IllegalStateException("주문에 연결된 Donation이 없습니다. orderId=" + order.getRequestId()));
+
+        // 트랜잭션 기록 (PG 결제)
+        var tx = transactionService.pgPayment(
+                donation.getUserId(),
+                confirmRequest.orderId(),
+                donation.getAmount(),
+                confirmRequest.paymentKey()
+        );
+
+        // Donation 완료 처리 + 트랜잭션 연결
+        donation.setTransaction(tx);
+        donation.markCompleted();
+        donationRepository.save(donation);
+    }
+
+    /**
+     * 직접 결제 후원
+     * - 사용자 ID, 결제 확인 요청 정보, 후원 아이템을 받아 직접 결제 후원 처리
+     * - PG 승인 요청, 거래 기록 생성, 후원 기록 생성 및 저장 순으로 처리
+     * - 중복 결제 방지 (이미 처리된 orderId가 있으면 예외 발생)
      * - PG 승인 실패 시 후원 실패 기록 저장 및 예외 발생
-     * - 중복 결제 방지 (이미 처리된 orderId인지 확인)
      * - 트랜잭션 처리 보장 (모든 작업이 성공해야 커밋, 하나라도 실패하면 롤백)
      *
      * @param userId 후원자 사용자 ID
@@ -128,7 +206,7 @@ public class DonationService {
     @Transactional
     public Donation donateWithPayment(Long userId, ConfirmRequest confirmRequest, Donation.DonationItem item) {
         // 1. 중복 결제 방지
-        // 이미 처리된 orderId인지 확인
+        // 중복된 orderId가 있으면 예외 발생
         if (transactionRepository.existsByOrderId(confirmRequest.orderId())) {
             throw new IllegalArgumentException("이미 처리된 후원 요청입니다. orderId=" + confirmRequest.orderId());
         }
@@ -138,6 +216,14 @@ public class DonationService {
             // PG 승인 요청
             paymentGatewayService.confirm(confirmRequest);
 
+            // 거래 기록 생성 및 저장
+            Transaction tx = transactionService.pgPayment(
+                    userId,                                             // 후원자 ID
+                    confirmRequest.orderId(),                           // 주문 ID
+                    item.getPrice(),                                    // 후원 금액
+                    confirmRequest.paymentKey()                         // 결제 키
+            );
+
             // 후원 기록 생성 (초기 상태는 REQUESTED)
             Donation donation = Donation.builder()
                     .userId(userId)                                     // 후원자 ID
@@ -145,28 +231,13 @@ public class DonationService {
                     .amount(item.getPrice())                            // 후원 금액
                     .donationType(Donation.DonationType.DIRECT)         // 직접 결제 후원
                     .donationStatus(Donation.DonationStatus.REQUESTED)  // 요청됨 상태
+                    .transaction(tx)                                    // 거래 정보 저장. 연관 관계 설정
                     .createdAt(LocalDateTime.now())
                     .updatedAt(LocalDateTime.now())
                     .build();                                           // 빌더 패턴으로 후원 엔티티 생성
 
-            // 트랜잭션 생성 및 저장
-            Transaction tx = transactionService.pgPayment(
-                    userId,
-                    confirmRequest.orderId(),
-                    item.getPrice(),
-                    confirmRequest.paymentKey()
-            );
-
-            // 후원 기록 업데이트
-            // 성공 처리 및 거래 정보 저장
-            donation.setDonationStatus(Donation.DonationStatus.COMPLETED);  // 성공 처리
-            donation.setTransaction(tx);                                    // 거래 정보 저장
-
             // 후원 기록 저장
-            donationRepository.save(donation);
-
-            // 결과 반환
-            return donation;
+            return donationRepository.save(donation);
         }
         // 예외 처리
         catch (RestClientException e) {
@@ -184,11 +255,6 @@ public class DonationService {
                     .createdAt(LocalDateTime.now())
                     .updatedAt(LocalDateTime.now())
                     .build();                                           // 빌더 패턴으로 후원 엔티티 생성
-
-
-            // 후원 기록 업데이트
-            failedDonation.setDonationStatus(Donation.DonationStatus.FAILED);     // 실패 처리
-            failedDonation.setErrorMessage(e.getMessage());                       // 에러 메시지 저장
 
             // 실패한 후원 기록 저장
             donationRepository.save(failedDonation);

--- a/src/main/java/com/projectboard/payment/order/Order.java
+++ b/src/main/java/com/projectboard/payment/order/Order.java
@@ -43,10 +43,11 @@ public class Order {
     private LocalDateTime updatedAt;
 
     // ===== 연관 관계 설정 =====
-    /** 1:1 양방향 연관 관계 설정
-     * - Order가 주인, Donation이 종속
-     * - Order의 PK가 Donation의 FK로 사용
-     * - fetch = FetchType.LAZY로 설정하여 지연 로딩 사용
+    /**
+     * 주문과 후원의 연관 관계
+     * - 1:1 양방향 연관 관계 설정.
+     * - Donation가 주인, Order가 종속.
+     * - fetch=LAZY로 설정하여 필요 시에만 로딩.
      */
     @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
     private Donation donation;                              // 연관된 후원 엔티티

--- a/src/main/java/com/projectboard/payment/order/Order.java
+++ b/src/main/java/com/projectboard/payment/order/Order.java
@@ -1,9 +1,8 @@
 package com.projectboard.payment.order;
 
+import com.projectboard.payment.donation.Donation;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -11,26 +10,31 @@ import java.time.LocalDateTime;
 /**
  * 주문 엔티티
  * - 사용자 주문 정보를 저장.
- * - 주문 상태 및 관련 메타데이터 포함.
+ * - 주문 금액, 상태 및 관련 메타데이터 포함.
+ * - Donation과의 1:1 양방향 연관 관계 설정.
  */
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
+@Builder
 @Entity
-@Table(name = "temp_order")
+@Table(name = "orders")
 public class Order {
+    // ===== 기본 필드 =====
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본 키, 자동 생성
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)     // 기본 키, 자동 생성
+    private Long id;                                        // 주문 ID (기본 키)
 
-    @Column(name = "user_id", nullable = false) // null 금지, 고유 제약 조건은 @Table에서 설정
-    private Long userId;
+    @Column(name = "user_id", nullable = false)             // null 금지, 고유 제약 조건은 @Table에서 설정
+    private Long userId;                                    // 사용자 ID
 
-    private BigDecimal amount;
+    @Column(nullable = false, precision = 19, scale = 2)    // 19자리 숫자, 소수점 이하 2자리
+    private BigDecimal amount;                              // 주문 금액
 
+    // 멱등성 보장을 위한 requestId 필드 추가
+    @Column(nullable = false, unique = true)
     private String requestId;
-    private Long donationId;
-    private String donationName;
 
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
@@ -38,6 +42,14 @@ public class Order {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    // ===== 연관 관계 설정 =====
+    /** 1:1 양방향 연관 관계 설정
+     * - Order가 주인, Donation이 종속
+     * - Order의 PK가 Donation의 FK로 사용
+     * - fetch = FetchType.LAZY로 설정하여 지연 로딩 사용
+     */
+    @OneToOne(mappedBy = "order", fetch = FetchType.LAZY)
+    private Donation donation;                              // 연관된 후원 엔티티
 
     // createdAt, updatedAt 자동 설정
     @PrePersist
@@ -51,5 +63,15 @@ public class Order {
     void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    // ===== 상태 변경 메서드 =====
+    // 대기 상태로 변경
+    public void waitStatus()    { this.status = OrderStatus.WAIT; }
+    // 요청 상태로 변경
+    public void requested()     { this.status = OrderStatus.REQUESTED; }
+    // 승인 상태로 변경
+    public void approved()      { this.status = OrderStatus.APPROVED; }
+    // 실패 상태로 변경
+    public void fail()          { this.status = OrderStatus.FAIL; }
 
 }

--- a/src/main/java/com/projectboard/payment/processing/PaymentProcessingService.java
+++ b/src/main/java/com/projectboard/payment/processing/PaymentProcessingService.java
@@ -2,6 +2,8 @@ package com.projectboard.payment.processing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.projectboard.payment.checkout.ConfirmRequest;
+import com.projectboard.payment.donation.Donation;
+import com.projectboard.payment.donation.DonationService;
 import com.projectboard.payment.external.PaymentGatewayService;
 import com.projectboard.payment.order.Order;
 import com.projectboard.payment.order.OrderRepository;
@@ -22,10 +24,9 @@ import java.time.LocalDateTime;
 
 /**
  * 결제 처리 서비스
- * - 결제 승인 요청 및 결제 기록 저장
- * - 충전 승인 요청 및 충전 기록 저장
- * - 주문 상태 업데이트 및 내역 저장
- * - 주문 서비스와 연동
+ * - 후원 결제 생성 및 충전 생성 기능 제공
+ * - 외부 결제 게이트웨이와의 통신, 거래 기록 저장, 주문 상태 업데이트 등 담당
+ * - 재시도 요청 생성 로직 포함
  */
 @Slf4j
 @Service
@@ -34,34 +35,20 @@ public class PaymentProcessingService {
     // ===== 의존성 주입 =====
     private final PaymentGatewayService paymentGatewayService;  // 외부 결제 게이트웨이 서비스
     private final TransactionService transactionService;        // 거래 기록 서비스
-
     private final OrderRepository orderRepository;              // 주문 리포지토리
-
+    private final DonationService donationService;              // 후원 서비스
     private final RetryRequestRepository retryRepository;       // 재시도 요청 리포지토리
-
     private ObjectMapper objectMapper;                          // JSON 객체 매퍼
 
     /**
-     * 결제 생성
-     * - 결제 승인 요청 및 결제 기록 저장
-     * - 주문 상태 업데이트 및 후원 내역 저장
+     * 후원 결제 생성
+     * - 결제 승인 요청 및 후원 기록 저장
      *
      * @param confirmRequest 결제 승인 요청 정보
      */
     public void createPayment(ConfirmRequest confirmRequest) {
-        // PG 승인 요청
-        paymentGatewayService.confirm(confirmRequest);
-
-        // 결제 기록 저장
-        transactionService.pgPayment(
-                    null,
-                    confirmRequest.orderId(),
-                    new BigDecimal(confirmRequest.amount()),
-                    confirmRequest.paymentKey()
-        );
-
-        // 주문 상태 변경
-        approveOrder(confirmRequest.orderId());
+        // PG 승인 요청 및 결제 기록 저장
+        donationService.completeDirectDonation(confirmRequest);
     }
 
     /**
@@ -117,7 +104,7 @@ public class PaymentProcessingService {
         );
 
         // 주문 상태 변경
-        approveOrder(confirmRequest.orderId());
+        approveOrder(order);
     }
 
     /**
@@ -144,12 +131,11 @@ public class PaymentProcessingService {
 
     /**
      * 주문 승인 처리
-     * - 주문 상태를 APPROVED로 변경하고 수정 시간 업데이트
+     * - 주문 상태를 APPROVED로 변경하고, 수정 시각 업데이트 후 저장
      *
-     * @param orderId 주문 ID
+     * @param order 승인할 주문 객체
      */
-    private void approveOrder(String orderId) {
-        final Order order = orderRepository.findByRequestId(orderId); // 주문 조회
+    private void approveOrder(Order order) {
         order.setStatus(OrderStatus.APPROVED);                        // 주문 상태 변경
         order.setUpdatedAt(LocalDateTime.now());                      // 주문 수정 시간 업데이트
         orderRepository.save(order);                                  // 변경 사항 저장

--- a/src/main/java/com/projectboard/payment/wallet/Wallet.java
+++ b/src/main/java/com/projectboard/payment/wallet/Wallet.java
@@ -1,31 +1,21 @@
 package com.projectboard.payment.wallet;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
  * 지갑 엔티티
- * - id: 지갑 ID (기본 키, 자동 생성)
- * - userId: 사용자 ID (고유 제약 조건)
- * - balance: 현재 잔액 (null 금지, 소수점 이하 2자리)
- * - version: 낙관적 락용 버전 필드
- * - createdAt: 생성 일시 (자동 설정)
- * - updatedAt: 수정 일시 (자동 갱신)
- *
- * 도메인 규칙:
- * - 충전(charge): 양수만 허용, 최대 한도 준수
- * - 결제(spend): 양수만 허용, 잔액 부족 금지
+ * - 사용자 ID에 고유 제약 조건(Unique Constraint) 설정
+ * - 잔액(balance)은 BigDecimal로 표현, 소수점 이하 2자리까지 허용
+ * - 낙관적 락을 위한 버전 필드 포함
+ * - 생성일(createdAt)과 수정일(updatedAt) 자동 관리
  */
 @Getter
+@Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Data
 @Entity
 @Table( // 지갑 테이블, userId에 고유 제약 조건(Unique Constraint) 설정
         name = "wallet", // 테이블명 지정
@@ -33,24 +23,25 @@ import java.time.LocalDateTime;
 )
 public class Wallet {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본 키, 자동 생성
+    @GeneratedValue(strategy = GenerationType.IDENTITY)             // 기본 키, 자동 생성
     private Long id;
 
-    @Column(name = "user_id", nullable = false) // null 금지, 고유 제약 조건은 @Table에서 설정
+    @Column(name = "user_id", nullable = false, unique = true)      // null 금지, 고유 제약 조건
     private Long userId;
 
-    @Column(nullable = false, precision = 19, scale = 2) // 19자리 숫자, 소수점 이하 2자리
-    private BigDecimal balance;
+    @Column(nullable = false, precision = 19, scale = 2)            // 19자리 숫자, 소수점 이하 2자리
+    private BigDecimal balance = BigDecimal.ZERO;                   // null 금지, 기본값 0
 
     @Version
-    private Long version; // 낙관적 락용 버전 필드
+    @Column(nullable = false)                                       // null 금지
+    private Long version = 0L;                                      // 낙관적 락 버전 필드, 기본값 0
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public Wallet(Long userId) {
         this.userId = userId;
-        this.balance = new BigDecimal(0);
+        this.balance = BigDecimal.ZERO;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/projectboard/payment/wallet/Wallet.java
+++ b/src/main/java/com/projectboard/payment/wallet/Wallet.java
@@ -26,7 +26,7 @@ public class Wallet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)             // 기본 키, 자동 생성
     private Long id;
 
-    @Column(name = "user_id", nullable = false, unique = true)      // null 금지, 고유 제약 조건
+    @Column(name = "user_id", nullable = false)                     // null 금지, 고유 제약 조건은 @Table에서 설정
     private Long userId;
 
     @Column(nullable = false, precision = 19, scale = 2)            // 19자리 숫자, 소수점 이하 2자리

--- a/src/main/java/com/projectboard/payment/wallet/WalletService.java
+++ b/src/main/java/com/projectboard/payment/wallet/WalletService.java
@@ -10,19 +10,30 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 
 /**
- * 지갑 서비스
- * - 지갑 생성, 조회, 잔액 변경(충전/차감) 기능 제공.
- * - 멱등성 보장 및 낙관적 락 재시도 로직 포함.
+ * 지갑 서비스 클래스
+ * - 지갑 생성, 조회, 잔액 추가(충전/차감) 기능 제공
+ * - 충전 한도(BALANCE_LIMIT) 설정
+ * - 낙관적 락(Optimistic Lock) 재시도 로직 포함
  */
 @RequiredArgsConstructor
 @Service
 public class WalletService {
-    // 비즈니스 상한
+    // ===== 상수 =====
+    // 충전 한도
+    // 잔액 1,000,000원 초과 불가
     private final BigDecimal BALANCE_LIMIT = new BigDecimal(1_000_000);
 
-    private final WalletRepository walletRepository;
+    // ===== 의존성 주입 =====
+    private final WalletRepository walletRepository;            // 지갑 리포지토리
 
-    // ===== 지갑 생성(멱등) =====
+    /**
+     * 지갑 생성
+     * - userId에 고유 제약 조건(Unique Constraint) 설정으로 멱등성 보장
+     * - 이미 존재하는 userId로 생성 시, 기존 지갑 반환
+     *
+     * @param request 지갑 생성 요청 정보
+     * @return 생성된 지갑 정보
+     */
     @Transactional
     public CreatedWalletResponse createWallet(CreateWalletRequest request) {
         // 멱등성 보장: userId에 고유 제약 조건(Unique Constraint) 설정
@@ -31,6 +42,7 @@ public class WalletService {
         try {
             // 새로운 지갑 생성
             Wallet wallet = walletRepository.save(new Wallet(request.userId()));
+
             // 결과 응답 반환
             return new CreatedWalletResponse(wallet.getId(), wallet.getUserId(), wallet.getBalance());
         }
@@ -39,19 +51,28 @@ public class WalletService {
         // → 재조회해서 결과 반환 (멱등성 보장)
         catch (DataIntegrityViolationException e) {
             // 기존 지갑 재조회
+            // 존재하지 않으면 예외 발생
             Wallet existing = walletRepository.findWalletByUserId(request.userId())
                     .orElseThrow(() -> new RuntimeException("이미 존재하는 지갑을 찾을 수 없습니다."));
+
             // 결과 응답 반환
             return new CreatedWalletResponse(existing.getId(), existing.getUserId(), existing.getBalance());
         }
     }
 
-    // ===== 지갑 ID로 지갑 조회 =====
+    /** 지갑 ID로 지갑 조회
+     * - 지갑 ID로 지갑을 조회하고, 없으면 예외 발생
+     *
+     * @param walletId 지갑 ID
+     * @return 조회된 지갑 정보
+     */
     @Transactional(readOnly = true)
     public FindWalletResponse findWalletByWalletId(Long walletId) {
         // 지갑 조회
+        // 존재하지 않으면 예외 발생
         Wallet wallet = walletRepository.findById(walletId)
                 .orElseThrow(() -> new WalletNotFoundException(walletId));
+
         // 결과 응답 반환
         return new FindWalletResponse(
                 wallet.getId(),
@@ -62,12 +83,41 @@ public class WalletService {
         );
     }
 
-    // FIXME: 테스트용이기에 추후 삭제 필요
-    // ===== 잔액 변경(충전/차감) + 낙관적 락 재시도 =====
+    /** 사용자 ID로 지갑 조회
+     * - 사용자 ID로 지갑을 조회하고, 없으면 예외 발생
+     *
+     * @param userId 사용자 ID
+     * @return 조회된 지갑 정보
+     */
+    @Transactional(readOnly = true)
+    public FindWalletResponse findWalletByUserId(Long userId) {
+        // 지갑 조회
+        // 존재하지 않으면 예외 발생
+        Wallet wallet = walletRepository.findWalletByUserId(userId)
+                .orElseThrow(() -> new WalletNotFoundException(userId));
+
+        // 결과 응답 반환
+        return new FindWalletResponse(
+                wallet.getId(),
+                wallet.getUserId(),
+                wallet.getBalance(),
+                wallet.getCreatedAt(),
+                wallet.getUpdatedAt());
+    }
+
+    /** 잔액 추가 (충전/차감)
+     * - 낙관적 락(Optimistic Lock) 재시도 로직 포함
+     * - 충전 한도(BALANCE_LIMIT) 초과 시 예외 발생
+     * - 잔액 변경 금액이 0이거나 null인 경우 예외 발생
+     *
+     * @param request 잔액 추가 요청 정보
+     * @return 변경된 지갑 정보
+     */
     @Transactional
     public AddBalanceWalletResponse addBalance(AddBalanceWalletRequest request) {
         // 변경 금액 검증
         BigDecimal amt = request.amount();
+
         // null 또는 0원인 경우 예외
         if (amt == null || amt.signum() == 0) {
             throw new IllegalArgumentException("변경 금액은 0일 수 없습니다.");

--- a/src/test/java/com/projectboard/payment/DonationServiceIntgTest.java
+++ b/src/test/java/com/projectboard/payment/DonationServiceIntgTest.java
@@ -102,7 +102,7 @@ public class DonationServiceIntgTest {
     }
 
     @Test
-    @DisplayName("포인트 후원 실패 - 잔액 부족 시 실패 Donation 저장")
+    @DisplayName("포인트 후원 실패 - 잔액 부족 시 Donation(FAILED) 저장")
     void donateWithPoint_insufficientBalance_thenFail() {
         // given
         // 1. 사용자 및 지갑 생성 (초기 잔액=0)
@@ -113,36 +113,37 @@ public class DonationServiceIntgTest {
 
         // when
         // 실제 서비스 호출
-        // 포인트로 후원 시도
-        // 잔액 부족으로 예외 발생 예상
-        // 예외 잡기 위해 catchThrowable 사용
-        Throwable thrown = catchThrowable(() -> donationService.donateWithPoint(userId, item));
+        // 잔액 부족으로 후원 실패 예상
+        Donation result = donationService.donateWithPoint(userId, item);
 
         // then
-        // 1. 예외 검증
-        // 잔액 부족으로 IllegalArgumentException 발생 예상
-        // 예외 메시지에 "잔액" 포함되어야 함
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("잔액");
+        // 1. 반환값 검증
+        // 후원 기록이 생성되어야 함
+        assertThat(result).isNotNull();
+        // 후원 상태가 FAILED여야 함
+        assertThat(result.getDonationStatus()).isEqualTo(Donation.DonationStatus.FAILED);
+        // 에러 메시지에 "잔액" 포함되어야 함
+        assertThat(result.getErrorMessage()).contains("잔액");
 
-        // 2. 실패한 후원 기록 검증
+        // 2. DB에 후원 기록이 저장되었는지 재확인
         // 모든 후원 기록 조회
         List<Donation> all = donationRepository.findAll();
         // 후원 기록이 1건 있어야 함
         assertThat(all).hasSize(1);
-        // 후원 상태가 FAILED여야 함
+        // 저장된 후원 기록이 방금 생성한 후원 기록과 동일해야 함
+        assertThat(all.get(0).getId()).isEqualTo(result.getId());
+        // 저장된 후원 기록의 상태가 FAILED여야 함
         assertThat(all.get(0).getDonationStatus()).isEqualTo(Donation.DonationStatus.FAILED);
 
-        // 3. DB에 지갑 잔액이 변동 없는지 재확인
-        // 지갑 잔액이 0원이어야 함
-        Wallet persisted = walletRepository.findWalletByUserId(userId)
-                .orElseThrow();
-        // 초기 잔액 0원 유지되어야 함
+        // 3. 지갑 잔액이 변동 없는지 재확인
+        // 지갑 재조회
+        Wallet persisted = walletRepository.findWalletByUserId(userId).orElseThrow();
+        // 잔액이 여전히 0이어야 함
         assertThat(persisted.getBalance()).isEqualByComparingTo("0");
 
         // 디버깅 출력
         System.out.printf("✅ point donation fail → userId=%d, status=%s, error=%s%n",
-                userId, all.get(0).getDonationStatus(), thrown.getMessage());
+                userId, result.getDonationStatus(), result.getErrorMessage());
     }
 
     @Test
@@ -171,8 +172,10 @@ public class DonationServiceIntgTest {
         assertThat(donation).isNotNull();
         // 후원 ID가 생성되어야 함
         assertThat(donation.getId()).isNotNull();
-        // 후원 상태가 COMPLETED여야 함
-        assertThat(donation.getDonationStatus()).isEqualTo(Donation.DonationStatus.COMPLETED);
+        // 후원 아이템이 요청한 아이템과 동일해야 함
+        assertThat(donation.getDonationItem()).isEqualTo(item);
+        // 후원 상태가 REQUESTED여야 함 (결제 승인 후 바로 COMPLETED로 변경되지 않음)
+        assertThat(donation.getDonationStatus()).isEqualTo(Donation.DonationStatus.REQUESTED);
         // 후원 금액이 후원 아이템 가격과 동일해야 함
         assertThat(donation.getAmount()).isEqualByComparingTo(item.getPrice());
 
@@ -195,22 +198,10 @@ public class DonationServiceIntgTest {
         List<Donation> all = donationRepository.findAll();
         // 후원 기록이 1건 있어야 함
         assertThat(all).hasSize(1);
-        // 저장된 후원 기록이 방금 생성한 후원 기록과 동일해야 함
-        assertThat(all.get(0).getDonationItem()).isEqualTo(item);
-        // 저장된 후원 기록의 상태가 COMPLETED여야 함
-        assertThat(all.get(0).getDonationStatus()).isEqualTo(Donation.DonationStatus.COMPLETED);
-        // 저장된 후원 기록의 트랜잭션이 null이 아니어야 함
+        // 후원 상태가 REQUESTED여야 함
+        assertThat(all.get(0).getDonationStatus()).isEqualTo(Donation.DonationStatus.REQUESTED);
+        // 연관된 트랜잭션이 존재해야 함
         assertThat(all.get(0).getTransaction()).isNotNull();
-        // 저장된 후원 기록의 트랜잭션의 orderId가 요청한 orderId와 동일해야 함
-        assertThat(all.get(0).getTransaction().getOrderId()).isEqualTo(orderId);
-        // 저장된 후원 기록의 트랜잭션의 userId가 후원자 ID와 동일해야 함
-        assertThat(all.get(0).getTransaction().getUserId()).isEqualTo(userId);
-        // 저장된 후원 기록의 트랜잭션의 amount가 후원 아이템 가격과 동일해야 함
-        assertThat(all.get(0).getTransaction().getAmount()).isEqualByComparingTo(item.getPrice());
-        // 저장된 후원 기록의 트랜잭션 타입이 PAYMENT여야 함
-        assertThat(all.get(0).getTransaction().getTransactionType()).isEqualTo(com.projectboard.payment.transaction.TransactionType.PAYMENT);
-        // 저장된 후원 기록의 트랜잭션의 지갑 ID가 null이어야 함
-        assertThat(all.get(0).getTransaction().getWalletId()).isNull();
 
         // 디버깅 출력
         System.out.printf("✅ direct donation ok → userId=%d, donationId=%d, txOrderId=%s%n",

--- a/src/test/java/com/projectboard/payment/DonationServiceTest.java
+++ b/src/test/java/com/projectboard/payment/DonationServiceTest.java
@@ -6,6 +6,9 @@ import com.projectboard.payment.donation.DonationRepository;
 import com.projectboard.payment.donation.DonationResponse;
 import com.projectboard.payment.donation.DonationService;
 import com.projectboard.payment.external.PaymentGatewayService;
+import com.projectboard.payment.order.Order;
+import com.projectboard.payment.order.OrderRepository;
+import com.projectboard.payment.order.OrderStatus;
 import com.projectboard.payment.transaction.Transaction;
 import com.projectboard.payment.transaction.TransactionRepository;
 import com.projectboard.payment.transaction.TransactionService;
@@ -18,12 +21,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.RestClientException;
 
 import java.math.BigDecimal;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -31,9 +37,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 /**
  * DonationServiceTest
@@ -79,6 +83,7 @@ public class DonationServiceTest {
     @Mock private PaymentGatewayService paymentGatewayService;      // 외부 결제 게이트웨이 서비스
     @Mock private TransactionService transactionService;            // 거래 서비스
     @Mock private TransactionRepository transactionRepository;      // 거래 리포지토리
+    @Mock private OrderRepository orderRepository;                  // 주문 리포지토리
     // SUT
     @InjectMocks private DonationService donationService;           // 후원 서비스
 
@@ -100,7 +105,7 @@ public class DonationServiceTest {
     }
 
     @Test
-    @DisplayName("포인트 후원 - 성공 (잔액 충분)")
+    @DisplayName("포인트 후원 - 성공 (지갑 차감 + Donation(COMPLETED) 저장)")
     void donateWithPoint_success() {
         // given
 
@@ -110,26 +115,20 @@ public class DonationServiceTest {
         // ===== 지갑 조회 및 잔액 차감 모킹 =====
         // 지갑 조회 모킹 (사용자 ID로 지갑 조회 시, 미리 생성한 지갑 반환)
         given(walletRepository.findWalletByUserId(userId)).willReturn(Optional.of(wallet));
-        // 지갑 저장 모킹 (변경된 잔액 반영된 지갑 반환)
-        // 잔액 차감 후, 저장된 지갑 객체 반환하도록 설정
-        given(walletRepository.save(any(Wallet.class))).willReturn(wallet);
-
-        // ===== 트랜잭션 생성 모킹 =====
-        // 포인트 후원 트랜잭션 생성
-        // 후원 아이템 가격에 해당하는 포인트 후원 트랜잭션 객체 생성
-        Transaction tx = Transaction.createPointDonationTransaction(userId, wallet.getId(), item.getPrice());
-        // 포인트 후원 트랜잭션 생성 시, 미리 생성한 트랜잭션 객체 반환하도록 설정
-        given(transactionService.createPointDonationTransaction(userId, wallet.getId(), item.getPrice()))
-                .willReturn(tx);
+        // 잔액 차감 모킹 (지갑 저장 시, 잔액에서 후원 아이템 가격 차감)
+        // 실제로는 walletRepository.save(wallet) 호출 시, 잔액이 차감된 상태로 저장됨
+        given(walletRepository.save(any(Wallet.class))).willAnswer(inv -> inv.getArgument(0));
 
         // ===== 후원 저장 모킹 =====
         // 저장된 후원 객체 생성
         Donation savedDonation = Donation.builder()                                     // 후원 엔티티 빌더 패턴으로 생성
-                .id(1L).userId(userId).donationItem(item)                               // 후원자 ID, 아이템 설정
+                .id(1L).userId(userId)                                                  // 후원자 ID 설정
+                .donationItem(item)                                                     // 후원 아이템 설정
                 .amount(item.getPrice())                                                // 후원 금액 설정
                 .donationType(Donation.DonationType.POINT)                              // 포인트 후원 유형 설정
                 .donationStatus(Donation.DonationStatus.COMPLETED)                      // 후원 상태 완료 설정
                 .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())          // 생성/수정 시각 설정
+                .wallet(wallet)                                                         // 연관된 지갑 설정
                 .build();
         // 후원 저장 시, ID가 부여된 후원 객체 반환하도록 설정
         given(donationRepository.save(any(Donation.class))).willReturn(savedDonation);
@@ -140,24 +139,28 @@ public class DonationServiceTest {
 
         // then
         // 결과 검증
+
         // 후원 결과가 null이 아닌지 확인
         assertThat(result).isNotNull();
         // 후원 상태가 COMPLETED인지 확인
         assertThat(result.getDonationStatus()).isEqualTo(Donation.DonationStatus.COMPLETED);
+
         // 후원 금액이 아이템 가격과 일치하는지 확인
         then(walletRepository).should(times(1)).save(wallet);
-        // 잔액이 후원 금액만큼 차감되었는지 확인
-        then(transactionService).should(times(1)).createPointDonationTransaction(userId, wallet.getId(), item.getPrice());
         // 후원 저장이 한 번 호출되었는지 확인
         then(donationRepository).should(times(1)).save(any(Donation.class));
 
+        // 잔액이 10,000 차감되었는지 확인
+        assertThat(wallet.getBalance()).isEqualByComparingTo(BigDecimal.valueOf(40_000));
+
         // 디버깅 출력
-        System.out.printf("🔎 donation success: id=%d, status=%s%n", result.getId(), result.getDonationStatus());
+        System.out.printf("🔎 donation success: id=%d, status=%s, item=%s%n",
+                result.getId(), result.getDonationStatus(), result.getDonationItem());
     }
 
     @Test
-    @DisplayName("포인트 후원 - 잔액 부족 시 실패 기록 저장 및 예외 발생")
-    void donateWithPoint_insufficientBalance_thenThrows() {
+    @DisplayName("포인트 후원 - 잔액 부족 시 Donation(FAILED) 저장 후 반환")
+    void donateWithPoint_insufficientBalance_returnsFailedDonation() {
         // given
 
         // 후원 아이템 설정 (생활용품, 50,000원)
@@ -171,37 +174,110 @@ public class DonationServiceTest {
 
         // ===== 후원 실패 기록 저장 모킹 =====
         // 잔액 부족 시, 후원 실패 기록 저장을 위해 save 호출 시 실패한 후원 객체 반환하도록 설정
-        Donation failedDonation = Donation.builder()                                // 후원 엔티티 빌더 패턴으로 생성
-                .userId(userId).donationItem(item).amount(item.getPrice())          // 후원자 ID, 아이템, 금액 설정
+        Donation failed = Donation.builder()                                // 후원 엔티티 빌더 패턴으로 생성
+                .id(2L).userId(userId)                                              // 후원자 ID 설정
+                .donationItem(item)                                                 // 후원 아이템 설정
+                .amount(item.getPrice())                                            // 후원 금액 설정
                 .donationType(Donation.DonationType.POINT)                          // 포인트 후원 유형 설정
                 .donationStatus(Donation.DonationStatus.FAILED)                     // 후원 상태 실패 설정
+                .errorMessage("잔액 부족")
                 .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())      // 생성/수정 시각 설정
                 .build();
         // 후원 저장 시, 실패한 후원 객체 반환하도록 설정
-        given(donationRepository.save(any(Donation.class))).willReturn(failedDonation);
+        given(donationRepository.save(any(Donation.class))).willReturn(failed);
 
         // when
         // 후원 서비스 호출 시 예외 발생 캡처
-        // 잔액 부족으로 인해 IllegalArgumentException 예외가 발생할 것으로 예상
-        Throwable thrown = catchThrowable(() -> donationService.donateWithPoint(userId, item));
+        Donation result = donationService.donateWithPoint(userId, item);
 
         // then
-        // 예외 검증
-        // 발생한 예외가 IllegalArgumentException인지 확인
-        // 예외 메시지에 "잔액이 부족" 문구가 포함되어 있는지 확인
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("잔액이 부족");
-        // 후원 저장이 한 번 호출되었는지 확인 (잔액 부족으로 인해 실패 기록 저장)
+        // 1. 결과 검증
+        // 후원 결과가 null이 아닌지 확인
+        assertThat(result).isNotNull();
+        // 후원 상태가 FAILED인지 확인
+        assertThat(result.getDonationStatus()).isEqualTo(Donation.DonationStatus.FAILED);
+        // 에러 메시지에 "잔액" 포함되어 있는지 확인
+        assertThat(result.getErrorMessage()).contains("잔액");
+
+        // 2. 저장 호출 검증
+        // 후원 저장이 한 번 호출되었는지 확인
         then(donationRepository).should(times(1)).save(any(Donation.class));
+        // 지갑 변경/저장은 수행되지 않음
+        then(walletRepository).should(never()).save(any());
 
         // 디버깅 출력
-        System.out.printf("🔎 donation failed: userId=%d, item=%s, ex=%s%n",
-                userId, item, thrown.getClass().getSimpleName());
+        System.out.printf("🔎 donation failed: id=%d, status=%s, error=%s%n",
+                result.getId(), result.getDonationStatus(), result.getErrorMessage());
     }
 
     @Test
-    @DisplayName("직접 결제 후원 - 성공 (PG 승인)")
-    void donateWithPayment_success() {
+    @DisplayName("직접 결제 준비 - Order(WAIT) 저장 + Donation(REQUESTED, DIRECT) 저장 + URL 반환")
+    void prepareDirectDonation_success() {
+        // given
+
+        // 후원 아이템 설정 (식료품, 30,000원)
+        Donation.DonationItem item = Donation.DonationItem.FOOD;
+        // ===== Order 저장 모킹 =====
+        // Order 저장 시, ID가 부여된 Order 객체 반환하도록 설정
+        // Order 저장 시, id 부여/createdAt 세팅 등은 엔티티 콜백으로 처리되니 그대로 반환
+        willAnswer(inv -> inv.getArgument(0)).given(orderRepository).save(any(Order.class));
+
+        // ===== Donation 저장 모킹 =====
+        // Donation 저장 시, ID가 부여된 Donation 객체 반환하도록 설정
+        Donation savedDonation = Donation.builder().id(100L).build();
+        // ID가 부여된 후원 객체 반환하도록 설정
+        given(donationRepository.save(any(Donation.class))).willReturn(savedDonation);
+
+        // when
+        // 후원 서비스 호출하여 결과 받기
+        String url = donationService.prepareDirectDonation(userId, item);
+
+        // then
+        // 1. URL 포맷 검증
+        // URL이 null이 아니고, /order?로 시작하는지 확인
+        assertThat(url).startsWith("/order?");
+        // 2. 파라미터 확인 (간단 파싱)
+        // URL에 userId, amount, donationId, donationName 파라미터가 포함되어 있는지 확인
+        assertThat(url).contains("userId=" + userId);
+        assertThat(url).contains("amount=" + item.getPrice().toPlainString());
+        assertThat(url).contains("donationId=" + 100L);
+        assertThat(URLDecoder.decode(url, StandardCharsets.UTF_8))
+                .contains("donationName=" + item.name());
+
+        // 3. 저장 호출 검증 + 상태값 검증 (캡쳐로 확인)
+        // Order 저장 검증
+        // Order 캡쳐 객체 생성
+        ArgumentCaptor<Order> orderCap = ArgumentCaptor.forClass(Order.class);
+        // Order 저장 시, 상태가 WAIT로 설정되었는지 확인
+        then(orderRepository).should().save(orderCap.capture());
+        // Order 상태가 WAIT인지 확인
+        assertThat(orderCap.getValue().getStatus()).isEqualTo(OrderStatus.WAIT);
+
+        // Donation 저장 검증
+        // Donation 캡쳐 객체 생성
+        ArgumentCaptor<Donation> donationCap = ArgumentCaptor.forClass(Donation.class);
+        // Donation 저장 시, 후원 유형이 DIRECT, 상태가 REQUESTED로 설정되었는지 확인
+        then(donationRepository).should().save(donationCap.capture());
+        // 저장된 Donation 객체 가져오기
+        var d = donationCap.getValue();
+        // 후원 유형이 DIRECT인지 확인
+        assertThat(d.getDonationType()).isEqualTo(Donation.DonationType.DIRECT);
+        // 후원 상태가 REQUESTED인지 확인
+        assertThat(d.getDonationStatus()).isEqualTo(Donation.DonationStatus.REQUESTED);
+        // 연관된 Order가 설정되었는지 확인
+        assertThat(d.getOrder()).isNotNull();
+
+        // PG 호출 없음 검증
+        then(paymentGatewayService).shouldHaveNoInteractions();  // 이 단계에서는 PG 호출 없음
+
+        // 디버깅 출력
+        System.out.printf("🔎 prepare direct donation: url=%s, orderId=%d, donationId=%d%n",
+                url, orderCap.getValue().getId(), donationCap.getValue().getId());
+    }
+
+    @Test
+    @DisplayName("직접 결제 완료 - 멱등성 통과 후 PG 승인 + Order.APPROVED + Donation(COMPLETED) + Tx 연결")
+    void completeDirectDonation_success() {
         // given
 
         // 후원 아이템 설정 (식료품, 30,000원)
@@ -212,13 +288,41 @@ public class DonationServiceTest {
         ConfirmRequest confirmRequest = new ConfirmRequest("payKey", "orderId-123", "30000");
 
         // ===== 중복 결제 방지 모킹 =====
+        // 1) 멱등성: 아직 처리된 트랜잭션이 없다
         // 주문 ID로 이미 처리된 거래가 없는지 확인 (중복 결제 방지)
         given(transactionRepository.existsByOrderId(confirmRequest.orderId())).willReturn(false);
 
         // ===== PG 승인 모킹 =====
+        // 2) PG 승인 OK
         // PG 승인 요청 모킹 (실제 외부 호출 없이 doNothing으로 처리)
         // PG 승인 요청이 성공적으로 처리되었다고 가정
         doNothing().when(paymentGatewayService).confirm(confirmRequest);
+
+        // ===== Order 조회 및 승인 모킹 =====
+        // 3) Order 조회/승인
+        Order order = Order.builder()                                                   // 주문 엔티티 빌더 패턴으로 생성
+                .id(777L).userId(userId)                                                // 주문자 ID 설정
+                .amount(BigDecimal.valueOf(30_000))                                     // 주문 금액 설정
+                .requestId(confirmRequest.orderId())                                    // 요청 ID 설정
+                .status(OrderStatus.WAIT)                                               // 초기 상태 WAIT 설정
+                .build();
+        // 주문 조회 시, 미리 생성한 주문 객체 반환하도록 설정
+        given(orderRepository.findByRequestId(confirmRequest.orderId())).willReturn(order);
+        // 주문 저장 시, 상태가 APPROVED로 변경된 주문 객체 반환하도록 설정
+        willAnswer(inv -> inv.getArgument(0)).given(orderRepository).save(any(Order.class));
+
+        // ===== 후원 저장 모킹 =====
+        // 저장된 후원 객체 생성
+        Donation savedDonation = Donation.builder()                                     // 후원 엔티티 빌더 패턴으로 생성
+                .id(10L).userId(userId).donationItem(item)                              // 후원자 ID, 아이템 설정
+                .amount(item.getPrice())                                                // 후원 금액 설정
+                .donationType(Donation.DonationType.DIRECT)                             // 직접 결제 후원 유형 설정
+                .donationStatus(Donation.DonationStatus.COMPLETED)                      // 후원 상태 완료 설정
+                .order(order)                                                           // 연관된 주문 설정
+                .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())          // 생성/수정 시각 설정
+                .build();
+        // 후원 저장 시, ID가 부여된 후원 객체 반환하도록 설정
+        given(donationRepository.findByOrder(order)).willReturn(Optional.of(savedDonation));
 
         // ===== 트랜잭션 생성 모킹 =====
         // PG 결제 트랜잭션 생성
@@ -227,40 +331,30 @@ public class DonationServiceTest {
         given(transactionService.pgPayment(userId, confirmRequest.orderId(), item.getPrice(), confirmRequest.paymentKey()))
                 .willReturn(tx);
 
-        // ===== 후원 저장 모킹 =====
-        // 저장된 후원 객체 생성
-        Donation savedDonation = Donation.builder()                                     // 후원 엔티티 빌더 패턴으로 생성
-                .id(10L).userId(userId).donationItem(item).amount(item.getPrice())      // 후원자 ID, 아이템, 금액 설정
-                .donationType(Donation.DonationType.DIRECT)                             // 직접 결제 후원 유형 설정
-                .donationStatus(Donation.DonationStatus.COMPLETED)                      // 후원 상태 완료 설정
-                .transaction(tx)                                                        // 연관된 트랜잭션 설정
-                .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())          // 생성/수정 시각 설정
-                .build();
-        // 후원 저장 시, ID가 부여된 후원 객체 반환하도록 설정
-        given(donationRepository.save(any(Donation.class))).willReturn(savedDonation);
-
         // when
         // 후원 서비스 호출하여 결과 받기
-        Donation result = donationService.donateWithPayment(userId, confirmRequest, item);
+        donationService.completeDirectDonation(confirmRequest);
 
         // then
-        // 결과 검증
-        // 후원 결과가 null이 아닌지 확인
-        assertThat(result).isNotNull();
-        // 후원 상태가 COMPLETED인지 확인
-        assertThat(result.getDonationStatus()).isEqualTo(Donation.DonationStatus.COMPLETED);
-        // 후원 금액이 아이템 가격과 일치하는지 확인
-        assertThat(result.getTransaction()).isEqualTo(tx);
-        // PG 승인 요청이 한 번 호출되었는지 확인
+        // 멱등성 통과로 PG 승인 요청이 한 번 호출되었는지 확인
         then(paymentGatewayService).should(times(1)).confirm(confirmRequest);
-        // 트랜잭션 생성이 한 번 호출되었는지 확인
-        then(transactionService).should(times(1)).pgPayment(userId, confirmRequest.orderId(), item.getPrice(), confirmRequest.paymentKey());
+
+        // 주문 상태가 APPROVED로 변경되어 저장되었는지 확인
+        then(orderRepository).should(times(1)).save(order);
+
+        // Donation 저장 시 COMPLETED/Tx 연결 확인
+        // Donation 캡쳐 객체 생성
+        ArgumentCaptor<Donation> cap = ArgumentCaptor.forClass(Donation.class);
         // 후원 저장이 한 번 호출되었는지 확인
-        then(donationRepository).should(times(1)).save(any(Donation.class));
+        then(donationRepository).should(times(1)).save(cap.capture());
+        // 후원 상태가 COMPLETED인지 확인
+        assertThat(cap.getValue().getDonationStatus()).isEqualTo(Donation.DonationStatus.COMPLETED);
+        // 트랜잭션이 연결되었는지 확인
+        assertThat(cap.getValue().getTransaction()).isEqualTo(tx);
 
         // 디버깅 출력
-        System.out.printf("🔎 donation success (PG): id=%d, status=%s, tx=%s%n",
-                result.getId(), result.getDonationStatus(), result.getTransaction().getOrderId());
+        System.out.printf("🔎 donation completed: userId=%d, orderId=%s, donationId=%d, txId=%d%n",
+                userId, confirmRequest.orderId(), savedDonation.getId(), tx.getId());
     }
 
     @Test
@@ -307,8 +401,8 @@ public class DonationServiceTest {
     }
 
     @Test
-    @DisplayName("직접 결제 후원 - 중복 orderId 시 예외 발생")
-    void donateWithPayment_whenDuplicateOrderId_thenThrows() {
+    @DisplayName("직접 결제 완료 - 이미 처리된 orderId면 아무 작업 없이 리턴(멱등성)")
+    void completeDirectDonation_idempotent() {
         // given
 
         // 후원 아이템 설정 (교재, 10,000원)
@@ -323,22 +417,22 @@ public class DonationServiceTest {
         given(transactionRepository.existsByOrderId(confirmRequest.orderId())).willReturn(true);
 
         // when
-        // 후원 서비스 호출 시 예외 발생 캡처
-        // 중복 orderId로 인해 IllegalArgumentException 예외가 발생할 것으로 예상
-        Throwable thrown = catchThrowable(() -> donationService.donateWithPayment(userId, confirmRequest, item));
+        // 후원 서비스 호출 (중복이므로 예외는 던지지 않고 조용히 종료)
+        donationService.completeDirectDonation(confirmRequest);
 
         // then
-        // 예외 검증
-        // 발생한 예외가 IllegalArgumentException인지 확인
-        // 예외 메시지에 "이미 처리된" 문구가 포함되어 있는지 확인
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("이미 처리된");
-        // 중복 확인을 위해 orderId 존재 여부 조회가 한 번 호출되었는지 확인
-        then(transactionRepository).should(times(1)).existsByOrderId(confirmRequest.orderId());
+        // 중복이므로 아무 작업도 수행하지 않았는지 검증
+        then(paymentGatewayService).shouldHaveNoInteractions();
+        // 주문 저장도 호출되지 않았는지 확인
+        then(orderRepository).shouldHaveNoInteractions();
+        // 후원 저장도 호출되지 않았는지 확인
+        then(donationRepository).shouldHaveNoInteractions();
+        // 트랜잭션 생성도 호출되지 않았는지 확인
+        then(transactionService).shouldHaveNoInteractions();
 
         // 디버깅 출력
-        System.out.printf("🔎 duplicate donation blocked: orderId=%s, ex=%s%n",
-                confirmRequest.orderId(), thrown.getClass().getSimpleName());
+        System.out.printf("🔎 donation skipped (duplicate): userId=%d, orderId=%s%n",
+                userId, confirmRequest.orderId());
     }
 
     @Test

--- a/src/test/java/com/projectboard/payment/PaymentProcessingServiceTest.java
+++ b/src/test/java/com/projectboard/payment/PaymentProcessingServiceTest.java
@@ -2,6 +2,7 @@ package com.projectboard.payment;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.projectboard.payment.checkout.ConfirmRequest;
+import com.projectboard.payment.donation.DonationService;
 import com.projectboard.payment.external.PaymentGatewayService;
 import com.projectboard.payment.order.Order;
 import com.projectboard.payment.order.OrderRepository;
@@ -83,6 +84,7 @@ public class PaymentProcessingServiceTest {
     @Mock private PaymentGatewayService paymentGatewayService;       // PG 서비스 (모킹)
     @Mock private TransactionService transactionService;             // 거래 서비스 (모킹)
     @Mock private OrderRepository orderRepository;                   // 주문 리포지토리 (모킹)
+    @Mock private DonationService donationService;                   // 후원 서비스 (모킹)
     @Mock private RetryRequestRepository retryRequestRepository;     // 재시도 리포지토리 (모킹)
 
     // JSON 처리용 ObjectMapper
@@ -97,6 +99,7 @@ public class PaymentProcessingServiceTest {
                 paymentGatewayService,
                 transactionService,
                 orderRepository,
+                donationService,
                 retryRequestRepository,
                 objectMapper
         );
@@ -110,7 +113,7 @@ public class PaymentProcessingServiceTest {
     }
 
     @Test
-    @DisplayName("PG 결제 성공 시 결제 기록이 생성되고 주문이 APPROVED 된다")
+    @DisplayName("PG 결제 성공 시 DonationService.completeDirectDonation으로 위임한다")
     void createPayment_success() {
         // given
         // ConfirmRequest 생성
@@ -120,49 +123,22 @@ public class PaymentProcessingServiceTest {
                 "1000"
         );
 
-        // ===== OrderRepository 스텁 설정 =====
-        // Order 생성 및 초기 상태 설정
-        Order order = new Order();               // 새로운 주문 객체 생성
-        order.setStatus(OrderStatus.REQUESTED);  // 초기 상태 설정
-        order.setUpdatedAt(LocalDateTime.now()); // 초기 업데이트 시간 설정
-
-        // orderRepository가 confirmRequest.orderId()로 호출될 때 order 객체를 반환하도록 스텁 설정
-        given(orderRepository.findByRequestId(confirmRequest.orderId()))
-                .willReturn(order);
-
         // when
         // 결제 처리 서비스의 createPayment 메서드 호출
         paymentProcessingService.createPayment(confirmRequest);
 
         // then
-        // 1. PG 승인 요청 확인
-        // 1번 호출되었는지 검증
-        then(paymentGatewayService).should(times(1)).confirm(confirmRequest);
+        // DonationService.completeDirectDonation이 호출되었는지 검증
+        then(donationService).should(times(1)).completeDirectDonation(confirmRequest);
 
-        // 2. 결제 기록 생성 확인
-        // 1번 호출되었는지 검증
-        then(transactionService).should(times(1)).pgPayment(
-                null,
-                confirmRequest.orderId(),
-                new BigDecimal(confirmRequest.amount()),
-                confirmRequest.paymentKey()
-        );
-
-        // 3. 주문 상태가 APPROVED 로 변경되었는지 확인
-        // order 객체의 상태가 APPROVED인지 검증
-        assertThat(order.getStatus()).isEqualTo(OrderStatus.APPROVED);
-
-        // 4. 주문 저장이 호출되었는지 확인
-        // 1번 호출되었는지 검증
-        then(orderRepository).should(times(1)).save(order);
-
-        // 그 외 불필요한 호출 없음
-        // then(paymentGatewayService).shouldHaveNoMoreInteractions();
-        // then(transactionService).shouldHaveNoMoreInteractions();
-        // then(orderRepository).shouldHaveNoMoreInteractions();
+        // 다른 의존성은 호출되지 않았는지 검증
+        // 더 이상 내부에서 직접 수행하지 않음
+        then(paymentGatewayService).shouldHaveNoInteractions();
+        then(transactionService).shouldHaveNoInteractions();
+        then(orderRepository).shouldHaveNoInteractions();
 
         // 디버깅 출력
-        System.out.println("Updated Order Status: " + order.getStatus());
+        System.out.printf("✅ orderId=%s%n", confirmRequest.orderId());
     }
 
     @Test
@@ -240,16 +216,6 @@ public class PaymentProcessingServiceTest {
         RestClientException timeoutEx = new RestClientException("timeout", new SocketTimeoutException("Read timed out"));
         willThrow(timeoutEx).given(paymentGatewayService).confirm(confirmRequest);
 
-        // ===== OrderRepository 스텁 설정 =====
-        // Order 생성 및 초기 상태 설정
-        Order order = new Order();
-        order.setUserId(1L);
-        order.setRequestId(confirmRequest.orderId());
-        order.setUpdatedAt(LocalDateTime.now());
-
-        // orderRepository가 confirmRequest.orderId()로 호출될 때 order 객체를 반환하도록 스텁 설정
-        given(orderRepository.findByRequestId(confirmRequest.orderId())).willReturn(order);
-
         // when & then
         // 결제 처리 서비스의 createCharge 메서드 호출 시 RestClientException 예외가 발생하는지 검증
         // isRetry: false (재시도 아님)
@@ -257,18 +223,21 @@ public class PaymentProcessingServiceTest {
                 .isInstanceOf(RestClientException.class)
                 .hasCauseInstanceOf(SocketTimeoutException.class);
 
-        // 1. PG 승인 요청이 호출되었는지 확인
-        // 1번 호출되었는지 검증
+        // 1. 호출 검증
+        // PG 승인 요청이 1번 호출되었는지 확인
         then(paymentGatewayService).should(times(1)).confirm(confirmRequest);
+        // 트랜잭션 충전 기록이 생성되지 않았는지 확인
+        then(transactionService).should(never()).charge(any());
+        // 주문 저장이 호출되지 않았는지 확인
+        then(orderRepository).shouldHaveNoMoreInteractions();
 
-        // 2. 트랜잭션 충전 기록이 생성되지 않았는지 확인
-        then(transactionService).should(never()).charge(any(ChargeTransactionRequest.class));
+        // 2. RetryRequest 저장 검증
+        // RetryRequest 가 저장되는지 검증하기 위해 ArgumentCaptor 사용
+        ArgumentCaptor<RetryRequest> captor = ArgumentCaptor.forClass(RetryRequest.class);
+        // save 메서드가 1번 호출되었는지 검증 및 인자 캡처
+        then(retryRequestRepository).should(times(1)).save(captor.capture());
 
-        // 3. 주문 상태가 변경되지 않았는지 확인
-        // order 객체의 상태가 변경되지 않았음을 검증
-        ArgumentCaptor<RetryRequest> captor = ArgumentCaptor.forClass(RetryRequest.class);   // ArgumentCaptor 생성
-        then(retryRequestRepository).should(times(1)).save(captor.capture()); // save 메서드가 1번 호출되었는지 검증 및 인자 캡처
-
+        // 3. 저장된 RetryRequest 필드 값 검증
         // 캡처된 RetryRequest 검증
         RetryRequest saved = captor.getValue();
         // saved 객체의 필드 값 검증
@@ -280,12 +249,9 @@ public class PaymentProcessingServiceTest {
         // 에러 응답 메시지에 "timeout" 문자열이 포함되어 있는지 검증
         assertThat(saved.getErrorResponse()).contains("timeout");
 
-        // 4. 주문 저장이 호출되지 않았는지 확인
-        then(orderRepository).should(never()).save(order);
-
         // 디버깅 출력
-        System.out.printf("✅ After Timeout: orderId=%s, userId=%d, status=%s%n",
-                order.getRequestId(), order.getUserId(), order.getStatus());
+        System.out.printf("✅ Saved RetryRequest: requestId=%s, type=%s, status=%s, errorResponse=%s%n",
+                saved.getRequestId(), saved.getType(), saved.getStatus(), saved.getErrorResponse());
     }
 
     @Test

--- a/src/test/java/com/projectboard/payment/WalletServiceIntgTest.java
+++ b/src/test/java/com/projectboard/payment/WalletServiceIntgTest.java
@@ -1,5 +1,6 @@
 package com.projectboard.payment;
 
+import com.projectboard.payment.donation.DonationRepository;
 import com.projectboard.payment.wallet.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * WalletService 통합 테스트
@@ -41,9 +41,12 @@ public class WalletServiceIntgTest {
     // 의존성 주입
     @Autowired WalletRepository walletRepository;           // 실제 리포지토리
 
+    @Autowired DonationRepository donationRepository;
+
     // 각 테스트 격리
     @AfterEach
     void tearDown() {
+        donationRepository.deleteAll();
         walletRepository.deleteAll();         // 트랜잭션이 지갑에 종속되어 있으므로, 지갑부터 삭제해야 함
     }
 
@@ -105,31 +108,42 @@ public class WalletServiceIntgTest {
         int numOfThreads = 20;
         ExecutorService service = Executors.newFixedThreadPool(numOfThreads); // 스레드풀 생성
         CountDownLatch latch = new CountDownLatch(numOfThreads);              // 모든 스레드 완료 대기용
+        // 생성된 지갑 ID를 저장할 동기화된 리스트
+        List<Long> createdIds = Collections.synchronizedList(new ArrayList<>());
 
         // when
-        // 모든 스레드에서 동시에 요청 시작
+        // 여러 스레드에서 동시에 createWallet() 호출
         for (int i = 0; i < numOfThreads; i++) {
-            // 각 스레드에서 지갑 생성 시도
-            service.submit(() -> {
+            service.submit(() -> {  // 스레드풀에서 작업 제출
                 try {
-                    walletService.createWallet(request); // 실제 서비스 호출
+                    var res = walletService.createWallet(new CreateWalletRequest(userId));  // 실제 서비스 호출
+                    createdIds.add(res.id());                                               // 생성된 지갑 ID 저장
                 } finally {
-                    latch.countDown();  // 완료 표시
+                    latch.countDown();                                                      // 작업 완료 신호
                 }
             });
         }
 
-        // 최대 10초 대기 (너무 오래 걸리면 타임아웃)
-        latch.await();      // 모든 스레드 완료 대기
-        service.shutdown(); // 스레드풀 종료
+        // 모든 스레드가 작업을 완료할 때까지 최대 10초 대기
+        boolean finished = latch.await(10, TimeUnit.SECONDS);
+        // 모든 작업이 10초 내에 끝나지 않으면 테스트 실패
+        assertThat(finished).as("동시 작업이 10초 내에 끝나야 함").isTrue();
+        // 스레드풀 종료
+        service.shutdown();
 
         // then
-        // 최종적으로 DB에 지갑이 1개만 존재하는지 확인
+        // 1. 모든 호출이 성공해야 함 (예외 발생하지 않아야 함)
         List<Wallet> wallets = walletRepository.findAll();
-        // 지갑은 유일하게 1개만 존재해야 한다
+        // 2. 지갑은 1개만 생성되어야 함
         assertThat(wallets).hasSize(1);
-        // 유일한 지갑의 userId가 요청한 userId와 동일해야 한다
+        // 3. 생성된 지갑의 userId는 요청한 userId와 동일해야 함
         assertThat(wallets.get(0).getUserId()).isEqualTo(userId);
+
+        // 4. 모든 호출에서 반환된 지갑 ID는 동일해야 함 (멱등성)
+        // Set으로 만들어 중복 제거 후 크기가 1이어야 함
+        assertThat(createdIds.stream().collect(Collectors.toSet())) // Set으로 변환하여 중복 제거
+                .hasSize(1)                                 // 크기가 1이어야 함
+                .containsExactly(wallets.get(0).getId());           // DB에 저장된 지갑 ID와 동일해야 함
 
         // 디버깅 출력
         System.out.printf("✅ 최종 지갑 개수: %d, userId=%d%n", wallets.size(), userId);


### PR DESCRIPTION
# PR: Order–Donation–Wallet 연관 관계 정리, 중복 필드 제거, 관련 코드 전반 리팩터링

## 📌 개요
- 결제/후원 도메인 내 `Order`, `Donation`, `Wallet` 엔티티의 연관 관계를 명확히 정의하고  
  중복 필드를 정리하여 도메인 모델을 일관되게 관리할 수 있도록 리팩터링했습니다.  
- 이와 함께 `Repository`, `Service`, `Controller`, `Test` 코드 전반을 리팩터링하여  
  불필요한 중복 제거 및 책임 분리를 강화했습니다.  

---

## 🔑 주요 변경 사항
### 1. 엔티티 연관 관계/필드 정리
- `Order`, `Donation`, `Wallet` 간 연관 관계 매핑 추가
  - `Donation` ↔ `Order` 단방향 연관관계 (`Donation`이 `Order` 참조)
  - `Wallet`은 `UserId` 기반으로 관리
- `Donation.amount`, `Order.amount` 등 중복 필드 정리 및 일관성 보장
- `createdAt`, `updatedAt` 관리 로직 통일

### 2. Repository 수정
- `DonationRepository`
  - `findByOrder(Order order)` 메서드 추가
  - Javadoc 보강 및 설명 주석 정리

### 3. Service 리팩터링
- `PaymentProcessingService`
  - `DonationService` 연동: 후원 결제 로직을 `donationService.completeDirectDonation()`으로 위임
  - 주문 상태 변경 메서드 시그니처 단순화 (`approveOrder(Order order)`)
  - 충전 로직과 결제 로직의 책임 분리

### 4. Controller 리팩터링
- `CheckoutController`
  - `requestId`가 QueryString 으로 전달되면 기존 `Order` 재사용
  - 신규 생성 시 `waitStatus()` 사용하여 초기 상태 관리
  - 모델 매핑 로직 단순화 및 가독성 향상

### 5. Test 코드 보강
- `WalletServiceTest`
  - 멱등 처리, 예외 상황(지갑 없음, 중복 생성, 잔액 부족, 한도 초과) 상세 검증
- `WalletServiceIntgTest`
  - 실제 DB 기반 통합 테스트 추가
  - 동시성 테스트로 `createWallet` 멱등성 보장 검증
- `PaymentProcessingServiceTest`
  - `DonationService` 위임 검증 추가
  - Timeout 상황 시 `RetryRequest` 저장 및 재시도 성공 케이스 검증
  - 기존 PG/트랜잭션 직접 검증 제거 → 책임을 DonationService/TransactionService 중심으로 전환

---

## ✅ 완료 조건
- [x] 엔티티 간 연관 관계 정의 및 중복 필드 정리
- [x] DonationRepository 확장 (`findByOrder`)
- [x] PaymentProcessingService → DonationService 위임 구조 반영
- [x] CheckoutControlle 리팩터링
- [x] WalletService 단위/통합 테스트 보강
- [x] PaymentProcessingService 테스트 수정 및 재시도 로직 검증

---

## 🚀 기대 효과
- 도메인 모델의 책임과 역할이 명확해져 유지보수성 향상
- 중복 필드 제거로 데이터 정합성 보장
- 테스트 보강을 통한 안정성 확보
- 후원 결제/충전 프로세스 확장 및 운영 시 장애 대응력 강화